### PR TITLE
Add onPreStart() method

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/NuAbstractProcessHandler.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuAbstractProcessHandler.java
@@ -28,6 +28,11 @@ public abstract class NuAbstractProcessHandler implements NuProcessHandler
 {
    /** {@inheritDoc} */
    @Override
+   public void onPreStart(NuProcess nuProcess) {
+   }
+
+   /** {@inheritDoc} */
+   @Override
    public void onStart(NuProcess nuProcess)
    {
    }

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessHandler.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessHandler.java
@@ -43,9 +43,32 @@ public interface NuProcessHandler
 {
    /**
     * This method is invoked when you call the {@link ProcessBuilder#start()}
+    * method. This is your opportunity to store away the {@code NuProcess}
+    * instance, possibly in your listener, so that it can be used for
+    * interaction within other callbacks in this interface.
+    * <p>
+    * Unlike the {@link #onStart(NuProcess)} method, this method is invoked
+    * before the process is spawned, and is guaranteed to be invoked before
+    * any other methods are called.
+    * 
+    * @param nuProcess
+    *    The {@link NuProcess} that is starting. Note that the instance is not
+    *    yet initialized, so it is not legal to call any of its methods, and
+    *    doing so will result in undefined behavior. If you need to call any
+    *    of the instance's methods, use {@link #onStart(NuProcess)} instead.
+    */
+   void onPreStart(NuProcess nuProcess);
+
+   /**
+    * This method is invoked when you call the {@link ProcessBuilder#start()}
     * method.  This is your opportunity to store away the {@code NuProcess}
     * instance, possibly in your listener, so that it can be used for
     * interaction within other callbacks in this interface.
+    * <p>
+    * Note that this method is called at some point after the process is spawned.
+    * It is possible for other methods (even {@link #onExit(int)}) to be called
+    * first. If you need a guarantee that no other methods will be called first,
+    * use {@link #onPreStart(NuProcess)} instead.
     *
     * @param nuProcess the {@link NuProcess} that is starting
     */

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -219,6 +219,8 @@ public abstract class BasePosixProcess implements NuProcess
 
    public NuProcess start(List<String> command, String[] environment)
    {
+      callPreStart();
+      
       String[] commands = command.toArray(new String[0]);
 
       Pointer posix_spawn_file_actions = createPipes();
@@ -540,6 +542,16 @@ public abstract class BasePosixProcess implements NuProcess
          catch (Exception e) {
             throw new RuntimeException(e);
          }
+      }
+   }
+
+   private void callPreStart()
+   {
+      try {
+         processHandler.onPreStart(this);
+      }
+      catch (Exception e) {
+    	// Don't let an exception thrown from the user's handler interrupt us
       }
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -221,6 +221,8 @@ public final class WindowsProcess implements NuProcess
 
    NuProcess start(List<String> commands, String[] environment)
    {
+      callPreStart();
+      
       try {
          createPipes();
 
@@ -452,6 +454,16 @@ public final class WindowsProcess implements NuProcess
          NuKernel32.CloseHandle(stdinPipe.pipeHandle);
       }
       inClosed = true;
+   }
+
+   private void callPreStart()
+   {
+      try {
+         processHandler.onPreStart(this);
+      }
+      catch (Exception e) {
+    	// Don't let an exception thrown from the user's handler interrupt us
+      }
    }
 
    private void callStart()


### PR DESCRIPTION
I've designed some reusable process handlers, and they need to re-initialize themselves when the process starts. onStart() is not (cannot be) guaranteed to be called before other methods are invoked (e.g. onStdout()), so I propose adding a onPreStart() method that is called before the process is spawned, that is guaranteed to be called before any other methods.