### PR TITLE
Load libc using NativeLibrary.getProcess()

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -50,8 +50,8 @@ public class NuProcessBuilder
 {
    private static final NuProcessFactory factory;
 
-   private List<String> command;
-   private TreeMap<String, String> environment;
+   private final List<String> command;
+   private final TreeMap<String, String> environment;
    private NuProcessHandler processListener;
 
    static {
@@ -81,6 +81,23 @@ public class NuProcessBuilder
       catch (Exception e) {
          throw new RuntimeException(e);
       }
+   }
+
+   /**
+    * Constructs a process builder with the specified operating system program and arguments. This constructor
+    * makes a copy of the command list.  Invokers of this constuctor must later call {@link #setProcessListener(NuProcessHandler)}
+    * in order to set a {@link NuProcessHandler} instance.
+    *
+    * @param commands a {@link List} of commands
+    * @param environment The environment for the process
+    */
+   public NuProcessBuilder(List<String> commands, Map<String, String> environment) {
+      if (commands == null || commands.isEmpty()) {
+         throw new IllegalArgumentException("List of commands may not be null or empty");
+      }
+
+      this.environment = new TreeMap<String, String>(environment);
+      this.command = new ArrayList<String>(commands);
    }
 
    /**

--- a/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
@@ -18,6 +18,7 @@ package com.zaxxer.nuprocess.internal;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.StringArray;
 import com.sun.jna.ptr.IntByReference;
@@ -25,7 +26,7 @@ import com.sun.jna.ptr.IntByReference;
 public class LibC
 {
    static {
-      Native.register("c");
+      Native.register(NativeLibrary.getProcess());
 
       if (System.getProperty("os.name").toLowerCase().contains("mac")
               || System.getProperty("os.name").toLowerCase().contains("freebsd")) {

--- a/src/main/java/com/zaxxer/nuprocess/linux/LibEpoll.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LibEpoll.java
@@ -17,6 +17,7 @@
 package com.zaxxer.nuprocess.linux;
 
 import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 
 /**
@@ -25,7 +26,7 @@ import com.sun.jna.Pointer;
 public class LibEpoll
 {
    static {
-      Native.register("c");
+      Native.register(NativeLibrary.getProcess());
    }
 
    public static native int sigignore(int signal);

--- a/src/main/java/com/zaxxer/nuprocess/osx/LibKevent.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/LibKevent.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 
@@ -29,7 +30,7 @@ import com.sun.jna.Structure;
 public class LibKevent
 {
    static {
-      Native.register("c");
+      Native.register(NativeLibrary.getProcess());
    }
 
    public static native int kqueue();


### PR DESCRIPTION
libc has already been mapped into the address space for you by the
runtime loader, ld.so, long before the jvm's main() entry point was
invoked.

The correct way in Java to get dlsym access to the existing runtime
linker symbol table is:

Native.register(NativeLibrary.getProcess())