### PR TITLE
Add destroyForcibly() method

### DIFF
--- a/src/example/java/com/zaxxer/nuprocess/example/SshExample.java
+++ b/src/example/java/com/zaxxer/nuprocess/example/SshExample.java
@@ -71,7 +71,7 @@ public class SshExample
 
         public void close()
         {
-            nuProcess.destroy();
+            nuProcess.destroy(false);
         }
 
         //Send key event

--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -93,35 +93,28 @@ public interface NuProcess
    boolean hasPendingWrites();
 
    /**
-    * Terminates the process. If possible, the process will be terminated gracefully (i.e.
-    * its shutdown logic will be allowed to execute).<br>
+    * Terminates the process.<br>
     * <br>
-    * Note that the process may not actually terminate when calling this method, as its
-    * cleanup logic may fail or it may choose to ignore the termination request. If a guarantee
-    * of termination is required, use {@link #destroyForcibly()} instead. You can also call
-    * {@link #waitFor(long, TimeUnit)} after calling this method, to give the process an
-    * opportunity to terminate gracefully. If the timeout expires, you can then call
-    * {@link #destroyForcibly()} to ensure the process is terminated.<br>
+    * If <code>force</code> is false, the process will be terminated gracefully (i.e. its
+    * shutdown logic will be allowed to execute), assuming the OS supports such behavior.
+    * Note that the process may not actually terminate, as its cleanup logic may fail or
+    * it may choose to ignore the termination request. If a guarantee of termination is
+    * required, call this method with <code>force</code> = true instead. You can also call
+    * {@link #waitFor(long, TimeUnit)} after calling this method with <code>force</code>
+    * = false, to give the process an opportunity to terminate gracefully. If the timeout
+    * expires, you can then call this method again with <code>force</code> = true to ensure
+    * the process is terminated.<br>
     * <br>
-    * When this method is called, the exit code returned by {@link #waitFor} or passed to the
-    * {@link NuProcessHandler#onExit} callback method is non-deterministic.
-    */
-   void destroy();
-   
-   /**
-    * Forcibly terminates the process. Whether this allows the process to terminate
-    * gracefully or not is OS-dependent, but unlike {@link #destroy()}, this method guarantees
-    * that the process will be terminated.<br>
-    * <br>
-    * Note that it may take the OS a moment to terminate the process, so {@link #isRunning()}
-    * may return true for a brief period after calling this method. You can use
-    * {@link #waitFor(long, TimeUnit)} if you want to wait until the process has actually
-    * been terminated.<br>
+    * If <code>force</code> is true, the process is guaranteed to terminate, but whether it
+    * is terminated gracefully or not is OS-dependent. Note that it may take the OS a moment
+    * to terminate the process, so {@link #isRunning()} may return true for a brief period
+    * after calling this method. You can use {@link #waitFor(long, TimeUnit)} if you want to
+    * wait until the process has actually been terminated.<br>
     * <br>
     * When this method is called, the exit code returned by {@link #waitFor} or passed to the
     * {@link NuProcessHandler#onExit} callback method is non-deterministic.
     */
-   void destroyForcibly();
+   void destroy(boolean force);
 
    /**
     * Tests whether or not the process is still running or has exited.

--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -93,11 +93,35 @@ public interface NuProcess
    boolean hasPendingWrites();
 
    /**
-    * Forcefully destroy the process.  When this method is called, the exit code returned by
-    * {@link #waitFor} or passed to the {@link NuProcessHandler#onExit} callback method is
-    * non-deterministic.  
+    * Terminates the process. If possible, the process will be terminated gracefully (i.e.
+    * its shutdown logic will be allowed to execute).<br>
+    * <br>
+    * Note that the process may not actually terminate when calling this method, as its
+    * cleanup logic may fail or it may choose to ignore the termination request. If a guarantee
+    * of termination is required, use {@link #destroyForcibly()} instead. You can also call
+    * {@link #waitFor(long, TimeUnit)} after calling this method, to give the process an
+    * opportunity to terminate gracefully. If the timeout expires, you can then call
+    * {@link #destroyForcibly()} to ensure the process is terminated.<br>
+    * <br>
+    * When this method is called, the exit code returned by {@link #waitFor} or passed to the
+    * {@link NuProcessHandler#onExit} callback method is non-deterministic.
     */
    void destroy();
+   
+   /**
+    * Forcibly terminates the process. Whether this allows the process to terminate
+    * gracefully or not is OS-dependent, but unlike {@link #destroy()}, this method guarantees
+    * that the process will be terminated.<br>
+    * <br>
+    * Note that it may take the OS a moment to terminate the process, so {@link #isRunning()}
+    * may return true for a brief period after calling this method. You can use
+    * {@link #waitFor(long, TimeUnit)} if you want to wait until the process has actually
+    * been terminated.<br>
+    * <br>
+    * When this method is called, the exit code returned by {@link #waitFor} or passed to the
+    * {@link NuProcessHandler#onExit} callback method is non-deterministic.
+    */
+   void destroyForcibly();
 
    /**
     * Tests whether or not the process is still running or has exited.

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -154,20 +154,11 @@ public abstract class BasePosixProcess implements NuProcess
 
    /** {@inheritDoc} */
    @Override
-   public void destroy()
+   public void destroy(boolean force)
    {
       if (isRunning) {
-    	  checkReturnCode(LibC.kill(pid, LibC.SIGTERM), "Sending SIGTERM failed");
+    	  checkReturnCode(LibC.kill(pid, force ? LibC.SIGTERM : LibC.SIGKILL), "Sending signal failed");
       }
-   }
-
-   /** {@inheritDoc} */
-   @Override
-   public void destroyForcibly()
-   {
-      if (isRunning) {
-         checkReturnCode(LibC.kill(pid, LibC.SIGKILL), "Sending SIGKILL failed");
-      }   
    }
 
    /** {@inheritDoc} */

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -157,7 +157,7 @@ public abstract class BasePosixProcess implements NuProcess
    public void destroy(boolean force)
    {
       if (isRunning) {
-    	  checkReturnCode(LibC.kill(pid, force ? LibC.SIGTERM : LibC.SIGKILL), "Sending signal failed");
+    	  checkReturnCode(LibC.kill(pid, force ? LibC.SIGKILL : LibC.SIGTERM), "Sending signal failed");
       }
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -157,12 +157,17 @@ public abstract class BasePosixProcess implements NuProcess
    public void destroy()
    {
       if (isRunning) {
-         LibC.kill(pid, LibC.SIGTERM);
-         IntByReference exit = new IntByReference();
-//         LibC.waitpid(pid, exit, 0);
-         isRunning = false;
-//         exitCode.set(exit.getValue());
+    	  checkReturnCode(LibC.kill(pid, LibC.SIGTERM), "Sending SIGTERM failed");
       }
+   }
+
+   /** {@inheritDoc} */
+   @Override
+   public void destroyForcibly()
+   {
+      if (isRunning) {
+         checkReturnCode(LibC.kill(pid, LibC.SIGKILL), "Sending SIGKILL failed");
+      }   
    }
 
    /** {@inheritDoc} */

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -194,17 +194,10 @@ public final class WindowsProcess implements NuProcess
    {
       return !pendingWrites.isEmpty();
    }
-
-   /** {@inheritDoc} */
-   @Override
-   public void destroy()
-   {
-      destroyForcibly();
-   }
    
    /** {@inheritDoc} */
    @Override
-   public void destroyForcibly()
+   public void destroy(boolean force)
    {
       NuKernel32.TerminateProcess(processInfo.hProcess, Integer.MAX_VALUE);
    }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -199,6 +199,13 @@ public final class WindowsProcess implements NuProcess
    @Override
    public void destroy()
    {
+      destroyForcibly();
+   }
+   
+   /** {@inheritDoc} */
+   @Override
+   public void destroyForcibly()
+   {
       NuKernel32.TerminateProcess(processInfo.hProcess, Integer.MAX_VALUE);
    }
 

--- a/src/test/java/com/zaxxer/nuprocess/InterruptTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/InterruptTest.java
@@ -88,14 +88,7 @@ public class InterruptTest
         {
             if (count.get() > 10000)
             {
-                if (forceKill)
-                {
-                    process.destroyForcibly();
-                }
-                else
-                {
-                    process.destroy();
-                }
+                process.destroy(forceKill);
                 break;
             }
             Thread.sleep(20);
@@ -168,7 +161,7 @@ public class InterruptTest
                         continue;
                     }
                     deadProcs.add(wp);
-                    wp.destroy();
+                    wp.destroy(false);
                 }
     
                 if (processes.isEmpty())

--- a/src/test/java/com/zaxxer/nuprocess/InterruptTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/InterruptTest.java
@@ -31,7 +31,18 @@ public class InterruptTest
     }
 
     @Test
-    public void testInterrupt1() throws InterruptedException
+    public void testDestroy() throws InterruptedException
+    {
+        testDestroy(false);
+    }
+    
+    @Test
+    public void testDestroyForcibly() throws InterruptedException
+    {
+        testDestroy(true);
+    }
+    
+    private void testDestroy(boolean forceKill) throws InterruptedException
     {
         final Semaphore semaphore = new Semaphore(0);
         final AtomicInteger exitCode = new AtomicInteger();
@@ -77,15 +88,22 @@ public class InterruptTest
         {
             if (count.get() > 10000)
             {
-                process.destroy();
+                if (forceKill)
+                {
+                    process.destroyForcibly();
+                }
+                else
+                {
+                    process.destroy();
+                }
                 break;
             }
             Thread.sleep(20);
         }
 
       semaphore.acquireUninterruptibly();
-		int exit = process.waitFor(2, TimeUnit.SECONDS);
-		Assert.assertTrue("Process exit code did not match", exit != 0);
+      int exit = process.waitFor(2, TimeUnit.SECONDS);
+      Assert.assertNotEquals("Process exit code did not match", 0, exit);
     }
 
     @Test


### PR DESCRIPTION
On *nix OSes, the NuProcess#destroy() method does not (cannot) guarantee that the process will terminate. It sends SIGTERM, which could be ignored by the target process. To deal with this, I have added a destroyForcibly() method similar to the one added to the JDK's Process class in Java 8. Calling destroyForcibly() sends SIGKILL, which is guaranteed to terminate the process. On Windows, destroy() and destroyForcibly() do the same thing, since TerminateProcess is already guaranteed to actually terminate the process.