### PR TITLE
Process cwd support for Mac, Linux, and Win32

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -212,14 +212,11 @@ public class NuProcessBuilder
     * Set the {@link Path} to which the current working directory (cwd) of the
     * subsequent launch of a {@link NuProcess} will be set when calling the {@link #start()} method.
     *
-    * @param cwd a {@link Path} to use for the process's current working directory
+    * @param cwd a {@link Path} to use for the process's current working directory, or {@code null}
+    *            to disable setting the cwd of subsequently launched proceses
     */
    public void setCwd(Path cwd)
    {
-      if (cwd == null) {
-         throw new IllegalArgumentException("A Path must be specified");
-      }
-
       this.cwd = cwd;
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -16,6 +16,7 @@
 
 package com.zaxxer.nuprocess;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +53,7 @@ public class NuProcessBuilder
 
    private final List<String> command;
    private final TreeMap<String, String> environment;
+   private Path cwd;
    private NuProcessHandler processListener;
 
    static {
@@ -207,6 +209,21 @@ public class NuProcessBuilder
    }
 
    /**
+    * Set the {@link Path} to which the current working directory (cwd) of the
+    * subsequent launch of a {@link NuProcess} will be set when calling the {@link #start()} method.
+    *
+    * @param cwd a {@link Path} to use for the process's current working directory
+    */
+   public void setCwd(Path cwd)
+   {
+      if (cwd == null) {
+         throw new IllegalArgumentException("A Path must be specified");
+      }
+
+      this.cwd = cwd;
+   }
+
+   /**
     * Spawn the child process with the configured commands, environment, and {@link NuProcessHandler}.
     *
     * @return a {@link NuProcess} instance or {@code null} if there is an immediately detectable launch failure
@@ -223,6 +240,6 @@ public class NuProcessBuilder
          env[i++] = entrySet.getKey() + "=" + entrySet.getValue();
       }
 
-      return factory.createProcess(command, env, processListener);
+      return factory.createProcess(command, env, processListener, cwd);
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -149,13 +149,16 @@ public abstract class BasePosixProcess implements NuProcess
       }
 
       if (IS_LINUX) {
-         linuxCwdExecutorService = new ThreadPoolExecutor(
+         ThreadPoolExecutor executor = new ThreadPoolExecutor(
              /* corePoolSize */ numThreads,
              /* maximumPoolSize */ numThreads,
-             /* keepAliveTime */ 0L, TimeUnit.MILLISECONDS,
+             /* keepAliveTime */ BaseEventProcessor.LINGER_TIME_MS, TimeUnit.MILLISECONDS,
              /* workQueue */ new LinkedBlockingQueue<Runnable>(),
              /* threadFactory */ new LinuxCwdThreadFactory(),
              /* handler */ new ThreadPoolExecutor.DiscardPolicy());
+         // Allow going back down to 0 threads after LINGER_TIME_MS.
+         executor.allowCoreThreadTimeOut(true);
+         linuxCwdExecutorService = executor;
       }
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
@@ -17,8 +17,10 @@
 package com.zaxxer.nuprocess.internal;
 
 import com.sun.jna.Callback;
+import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
+import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import com.sun.jna.StringArray;
 import com.sun.jna.ptr.IntByReference;
@@ -75,6 +77,20 @@ public class LibC
                                          Pointer /*const posix_spawnattr_t*/restrict_attrp, StringArray /*String[]*/argv, Pointer /*String[]*/envp);
 
    public static native Pointer signal(int signal, Pointer func);
+
+   public static native int chdir(String path);
+
+   public static native String getcwd(Pointer buf, int size);
+
+   // from /usr/include/sys/syscall.h
+   // We can't use JNA direct mapping for syscall(), since it takes varargs.
+   public interface SyscallLibrary extends Library {
+      public static final int SYS___pthread_chdir = 348;
+      int syscall(int syscall_number, Object... args);
+   }
+
+   public static SyscallLibrary SYSCALL = (SyscallLibrary) Native.loadLibrary(
+      Platform.C_LIBRARY_NAME, SyscallLibrary.class);
 
    public static final int F_GETFL = 3;
    public static final int F_SETFL = 4;

--- a/src/main/java/com/zaxxer/nuprocess/internal/LinuxLibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LinuxLibC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Brett Wooldridge
+ * Copyright (C) 2015 Ben Hamilton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package com.zaxxer.nuprocess;
+package com.zaxxer.nuprocess.internal;
 
-import java.util.List;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
 
-import java.nio.file.Path;
-
-/**
- * <b>This is an internal class.</b>  Instances of this interface create and start processes
- * in a platform-specific fashion.  
- *
- * @author Brett Wooldridge
- */
-public interface NuProcessFactory
+public class LinuxLibC
 {
-   NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd);
+   static {
+      Native.register(Platform.C_LIBRARY_NAME);
+   }
+
+   // from /usr/include/sched.h
+   public static native int unshare(int flags);
+
+   // from /usr/include/bits/sched.h
+   public static final int CLONE_FS = 0x00000200; /* Share or unshare cwd between threads / processes */
 }

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinProcessFactory.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.nuprocess.linux;
 
+import java.nio.file.Path;
+
 import java.util.List;
 
 import com.zaxxer.nuprocess.NuProcess;
@@ -31,11 +33,11 @@ public class LinProcessFactory implements NuProcessFactory
 {
    /** {@inheritDoc} */
    @Override
-   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener)
+   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
    {
       LinuxProcess process = new LinuxProcess(processListener);
       synchronized (LinProcessFactory.class) {
-         process.start(commands, env);
+         process.start(commands, env, cwd);
       }
       return process;
    }

--- a/src/main/java/com/zaxxer/nuprocess/osx/OsxProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/OsxProcessFactory.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.nuprocess.osx;
 
+import java.nio.file.Path;
+
 import java.util.List;
 
 import com.zaxxer.nuprocess.NuProcess;
@@ -26,10 +28,10 @@ public class OsxProcessFactory implements NuProcessFactory
 {
    /** {@inheritDoc} */
    @Override
-   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener)
+   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
    {
       OsxProcess process = new OsxProcess(processListener);
-      process.start(commands, env);
+      process.start(commands, env, cwd);
       return process;
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
@@ -47,7 +47,7 @@ public class NuKernel32
 
    public static native boolean CreateProcessW(WString lpApplicationName, char[] lpCommandLine, WinBase.SECURITY_ATTRIBUTES lpProcessAttributes,
                                                WinBase.SECURITY_ATTRIBUTES lpThreadAttributes, boolean bInheritHandles, DWORD dwCreationFlags,
-                                               Pointer lpEnvironment, String lpCurrentDirectory, WinBase.STARTUPINFO lpStartupInfo,
+                                               Pointer lpEnvironment, char[] lpCurrentDirectory, WinBase.STARTUPINFO lpStartupInfo,
                                                WinBase.PROCESS_INFORMATION lpProcessInformation);
 
    public static native boolean TerminateProcess(HANDLE hProcess, int exitCode);

--- a/src/main/java/com/zaxxer/nuprocess/windows/WinProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WinProcessFactory.java
@@ -19,6 +19,8 @@
  */
 package com.zaxxer.nuprocess.windows;
 
+import java.nio.file.Path;
+
 import java.util.List;
 
 import com.zaxxer.nuprocess.NuProcess;
@@ -34,10 +36,10 @@ public class WinProcessFactory implements NuProcessFactory
 {
    /** {@inheritDoc} */
    @Override
-   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener)
+   public NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
    {
       WindowsProcess process = new WindowsProcess(processListener);
-      process.start(commands, env);
+      process.start(commands, env, cwd);
       return process;
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -16,6 +16,7 @@
 
 package com.zaxxer.nuprocess.windows;
 
+import java.nio.file.Path;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -194,7 +195,7 @@ public final class WindowsProcess implements NuProcess
    {
       return !pendingWrites.isEmpty();
    }
-   
+
    /** {@inheritDoc} */
    @Override
    public void destroy(boolean force)
@@ -220,10 +221,10 @@ public final class WindowsProcess implements NuProcess
    //                          Package-scoped methods
    // ************************************************************************
 
-   NuProcess start(List<String> commands, String[] environment)
+   NuProcess start(List<String> commands, String[] environment, Path cwd)
    {
       callPreStart();
-      
+
       try {
          createPipes();
 
@@ -242,8 +243,14 @@ public final class WindowsProcess implements NuProcess
          processInfo = new PROCESS_INFORMATION();
 
          DWORD dwCreationFlags = new DWORD(WinNT.CREATE_NO_WINDOW | WinNT.CREATE_UNICODE_ENVIRONMENT | WinNT.CREATE_SUSPENDED);
+         char[] cwdChars;
+         if (cwd != null) {
+           cwdChars = Native.toCharArray(cwd.toAbsolutePath().toString());
+         } else {
+           cwdChars = null;
+         }
          if (!NuKernel32.CreateProcessW(null, getCommandLine(commands), null /*lpProcessAttributes*/, null /*lpThreadAttributes*/, true /*bInheritHandles*/,
-                                        dwCreationFlags, env, null /*lpCurrentDirectory*/, startupInfo, processInfo)) {
+                                        dwCreationFlags, env, cwdChars, startupInfo, processInfo)) {
             int lastError = Native.getLastError();
             throw new RuntimeException("CreateProcessW() failed, error: " + lastError);
          }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -243,12 +243,7 @@ public final class WindowsProcess implements NuProcess
          processInfo = new PROCESS_INFORMATION();
 
          DWORD dwCreationFlags = new DWORD(WinNT.CREATE_NO_WINDOW | WinNT.CREATE_UNICODE_ENVIRONMENT | WinNT.CREATE_SUSPENDED);
-         char[] cwdChars;
-         if (cwd != null) {
-           cwdChars = Native.toCharArray(cwd.toAbsolutePath().toString());
-         } else {
-           cwdChars = null;
-         }
+         char[] cwdChars = (cwd != null) ? Native.toCharArray(cwd.toAbsolutePath().toString()) : null;
          if (!NuKernel32.CreateProcessW(null, getCommandLine(commands), null /*lpProcessAttributes*/, null /*lpThreadAttributes*/, true /*bInheritHandles*/,
                                         dwCreationFlags, env, cwdChars, startupInfo, processInfo)) {
             int lastError = Native.getLastError();

--- a/src/test/java/com/zaxxer/nuprocess/CatTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/CatTest.java
@@ -72,7 +72,7 @@ public class CatTest
 
             Semaphore[] semaphores = new Semaphore[100];
             LottaProcessListener[] listeners = new LottaProcessListener[100];
-
+    
             for (int i = 0; i < semaphores.length; i++)
             {
                 semaphores[i] = new Semaphore(0);
@@ -81,12 +81,12 @@ public class CatTest
                 pb.start();
                 // System.err.printf("  starting process: %d\n", i + 1);
             }
-
+    
             for (Semaphore sem : semaphores)
             {
                 sem.acquire();
             }
-
+            
             for (LottaProcessListener listen : listeners)
             {
                 Assert.assertTrue("Adler32 mismatch between written and read", listen.checkAdlers());
@@ -104,12 +104,12 @@ public class CatTest
         for (int i = 0; i < 100; i++)
         {
             Semaphore semaphore = new Semaphore(0);
-
+    
             LottaProcessListener processListener = new LottaProcessListener(semaphore);
             NuProcessBuilder pb = new NuProcessBuilder(processListener, command);
             pb.start();
             semaphore.acquireUninterruptibly();
-
+    
             Assert.assertTrue("Adler32 mismatch between written and read", processListener.checkAdlers());
         }
 
@@ -175,7 +175,7 @@ public class CatTest
         int syncExitCode = nuProcess.waitFor(5, TimeUnit.SECONDS);
         boolean countedDown = exitLatch.await(5, TimeUnit.SECONDS);
         Assert.assertTrue("Async exit latch was not triggered", countedDown);
-
+        
         int expectedExitCode = System.getProperty("os.name").toLowerCase().contains("win") ? -1 : 1;
         Assert.assertEquals("Exit code (synchronous) did not match expectation", expectedExitCode, syncExitCode);
         Assert.assertEquals("Exit code (asynchronous) did not match expectation", expectedExitCode, asyncExitCode.get());
@@ -208,56 +208,56 @@ public class CatTest
 
         System.err.println("Completed test noExecutableFound()");
     }
-
+    
     @Test
     public void callbackOrder() throws InterruptedException
     {
         final List<String> callbacks = new CopyOnWriteArrayList<String>();
         final CountDownLatch latch = new CountDownLatch(1);
-
+        
         NuProcessHandler handler = new NuProcessHandler() {
             private NuProcess nuProcess;
-
+            
             @Override
             public void onStdout(ByteBuffer buffer, boolean closed) {
                 callbacks.add("stdout");
                 nuProcess.closeStdin();
             }
-
+            
             @Override
             public boolean onStdinReady(ByteBuffer buffer) {
                 callbacks.add("stdin");
                 buffer.put("foobar".getBytes()).flip();
                 return false;
             }
-
+            
             @Override
             public void onStderr(ByteBuffer buffer, boolean closed) {
                 callbacks.add("stderr");
             }
-
+            
             @Override
             public void onStart(NuProcess nuProcess) {
                 callbacks.add("start");
                 this.nuProcess = nuProcess;
                 nuProcess.wantWrite();
             }
-
+            
             @Override
             public void onPreStart(NuProcess nuProcess) {
                 callbacks.add("prestart");
             }
-
+            
             @Override
             public void onExit(int exitCode) {
                 callbacks.add("exit");
                 latch.countDown();
             }
         };
-
+        
         Assert.assertNotNull("process is null", new NuProcessBuilder(handler, command).start());
         latch.await();
-
+        
         Assert.assertEquals("onPreStart was not called first", 0, callbacks.indexOf("prestart"));
         Assert.assertFalse("onExit was called before onStdout", callbacks.indexOf("exit") < callbacks.lastIndexOf("stdout"));
     }
@@ -302,7 +302,7 @@ public class CatTest
         private Adler32 readAdler32;
         private Adler32 writeAdler32;
         private byte[] bytes;
-
+        
 
         LottaProcessListener(Semaphore semaphore)
         {


### PR DESCRIPTION
This implements setting the current working directory for a launched process on OS X, Linux, and Win32. Since calling `chdir()` affects every thread in the process, we have to use different strategies on each OS.

1. Win32: Pretty easy: `CreateProcessW()` already supports passing in the current directory as a `U+0000`-terminated array.
2. OS X: Also fairly easy: `syscall(SYS___pthread_chdir, cwd)` allows us to temporarily override the thread's current directory before we spawn the process, then we restore it.
3. Linux: This one is more difficult. We create a thread pool from which we use the `unshare(CLONE_FS)` API to disassociate the calling thread's cwd from the rest of the process. Then we call `chdir()` from that thread before we spawn the process.

I included a unit test. I made sure everything works on Windows, Mac, and Linux.

This does depend on the Java 7 `Path` API.