### PR TITLE
Remove timeout in kevent call

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
@@ -28,7 +28,6 @@ import com.sun.jna.ptr.IntByReference;
 import com.zaxxer.nuprocess.internal.BaseEventProcessor;
 import com.zaxxer.nuprocess.internal.LibC;
 import com.zaxxer.nuprocess.osx.LibKevent.Kevent;
-import com.zaxxer.nuprocess.osx.LibKevent.TimeSpec;
 
 import static com.zaxxer.nuprocess.internal.LibC.*;
 
@@ -38,7 +37,6 @@ import static com.zaxxer.nuprocess.internal.LibC.*;
 final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
 {
    private static final int NUM_KEVENTS = 64;
-   private static final TimeSpec timeSpec;
    private static final int JAVA_PID;
 
    private volatile int kqueue;
@@ -48,10 +46,6 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
 
    static {
       JAVA_PID = LibC.getpid();
-
-      timeSpec = new TimeSpec();
-      timeSpec.tv_sec = 0;
-      timeSpec.tv_nsec = TimeUnit.MILLISECONDS.toNanos(DEADPOOL_POLL_INTERVAL);
    }
 
    ProcessKqueue() {
@@ -170,7 +164,7 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
    public boolean process()
    {
       Kevent[] kevents = keventArray.get();
-      int nev = LibKevent.kevent(kqueue, null, 0, kevents[0].getPointer(), NUM_KEVENTS, timeSpec);
+      int nev = LibKevent.kevent(kqueue, null, 0, kevents[0].getPointer(), NUM_KEVENTS, null);
       if (nev == -1) {
          throw new RuntimeException("Error waiting for kevent");
       }


### PR DESCRIPTION
Unlike Linux and Win32, OS X has async notifications of child process exit via `NOTE_EXIT`, so there's no point in waking up each processor thread every 100 ms (or whatever the linger and poll intervals indicate) and do nothing.

This diff simply removes the timeout passed to `kevent()`, since we don't do any work if there are no events raised anyway.