### PR TITLE
Remove ThreadLocal in keventArray

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
@@ -78,8 +78,6 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
       catch (Exception e) {
          // TODO: how to handle this error?
          isRunning.set(false);
-      } finally {
-         cleanup();
       }
    }
 
@@ -111,10 +109,4 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
          LibC.waitpid(process.getPid(), exitCode, LibC.WNOHANG);
       }
    }
-
-   /**
-    * Invoked when the event processor is cleaning up. Override this
-    * to clean up any resources allocated by your event processor.
-    */
-   protected void cleanup() { }
 }


### PR DESCRIPTION
The `ThreadLocal<Kevent[]>` in `ProcessKqueue` was unnecessary and in fact introduced a bug: if `process()` invoked `checkWaitWrites()`, the second method would overwrite the contents of the `ThreadLocal`.

We only really care about re-using the `Kevent[]` in `process()` anyway, so this removes the `ThreadLocal` entirely in favor of a single `Kevent[]` which is only used from the constructor and from `process()`.