### PR TITLE
Remove dependency on jna-platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
     <dependencies>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna-platform</artifactId>
-            <version>4.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
             <version>4.1.0</version>
         </dependency>

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
@@ -24,15 +24,17 @@ import com.sun.jna.NativeLibrary;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.WString;
-import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
-import com.sun.jna.platform.win32.BaseTSD.ULONG_PTRByReference;
-import com.sun.jna.platform.win32.WinBase;
-import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
-import com.sun.jna.platform.win32.WinDef.DWORD;
-import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.W32APIOptions;
+
+import com.zaxxer.nuprocess.windows.NuWinNT.DWORD;
+import com.zaxxer.nuprocess.windows.NuWinNT.HANDLE;
+import com.zaxxer.nuprocess.windows.NuWinNT.SECURITY_ATTRIBUTES;
+import com.zaxxer.nuprocess.windows.NuWinNT.PROCESS_INFORMATION;
+import com.zaxxer.nuprocess.windows.NuWinNT.STARTUPINFO;
+import com.zaxxer.nuprocess.windows.NuWinNT.ULONG_PTRByReference;
+import com.zaxxer.nuprocess.windows.NuWinNT.ULONG_PTR;
 
 public class NuKernel32
 {
@@ -45,17 +47,17 @@ public class NuKernel32
 
    public static native HANDLE CreateIoCompletionPort(HANDLE fileHandle, HANDLE existingCompletionPort, ULONG_PTR completionKey, int numberOfThreads);
 
-   public static native boolean CreateProcessW(WString lpApplicationName, char[] lpCommandLine, WinBase.SECURITY_ATTRIBUTES lpProcessAttributes,
-                                               WinBase.SECURITY_ATTRIBUTES lpThreadAttributes, boolean bInheritHandles, DWORD dwCreationFlags,
-                                               Pointer lpEnvironment, char[] lpCurrentDirectory, WinBase.STARTUPINFO lpStartupInfo,
-                                               WinBase.PROCESS_INFORMATION lpProcessInformation);
+   public static native boolean CreateProcessW(WString lpApplicationName, char[] lpCommandLine, SECURITY_ATTRIBUTES lpProcessAttributes,
+                                               SECURITY_ATTRIBUTES lpThreadAttributes, boolean bInheritHandles, DWORD dwCreationFlags,
+                                               Pointer lpEnvironment, char[] lpCurrentDirectory, STARTUPINFO lpStartupInfo,
+                                               PROCESS_INFORMATION lpProcessInformation);
 
    public static native boolean TerminateProcess(HANDLE hProcess, int exitCode);
 
-   public static native HANDLE CreateFile(WString lpFileName, int dwDesiredAccess, int dwShareMode, WinBase.SECURITY_ATTRIBUTES lpSecurityAttributes,
+   public static native HANDLE CreateFile(WString lpFileName, int dwDesiredAccess, int dwShareMode, SECURITY_ATTRIBUTES lpSecurityAttributes,
                                           int dwCreationDisposition, int dwFlagsAndAttributes, HANDLE hTemplateFile);
 
-   public static native HANDLE CreateEvent(WinBase.SECURITY_ATTRIBUTES lpEventAttributes, boolean bManualReset, boolean bInitialState, String lpName);
+   public static native HANDLE CreateEvent(SECURITY_ATTRIBUTES lpEventAttributes, boolean bManualReset, boolean bInitialState, String lpName);
 
    public static native int WaitForSingleObject(HANDLE hHandle, int dwMilliseconds);
 
@@ -83,7 +85,7 @@ public class NuKernel32
                                       NuKernel32.OVERLAPPED lpOverlapped);
 
    /**
-    * The OVERLAPPED structure contains information used in 
+    * The OVERLAPPED structure contains information used in
     * asynchronous (or overlapped) input and output (I/O).
     */
    public static class OVERLAPPED extends Structure

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuWinNT.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuWinNT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2015 Ben Hamilton
+ *
+ * Originally from JNA com.sun.jna.platform.win32 package (Apache
+ * License, Version 2.0)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.nuprocess.windows;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.sun.jna.FromNativeContext;
+import com.sun.jna.IntegerType;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
+import com.sun.jna.Structure;
+import com.sun.jna.WString;
+import com.sun.jna.ptr.ByteByReference;
+import com.sun.jna.ptr.ByReference;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.NativeLongByReference;
+import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.W32APIOptions;
+
+/**
+ * Constants and structures for Windows APIs, borrowed from com.sun.jna.platform.win32
+ * to avoid pulling in a dependency on that package.
+ */
+public interface NuWinNT {
+   int CREATE_SUSPENDED = 0x00000004;
+   int CREATE_UNICODE_ENVIRONMENT = 0x00000400;
+   int CREATE_NO_WINDOW = 0x08000000;
+
+   int ERROR_SUCCESS = 0;
+   int ERROR_BROKEN_PIPE = 109;
+   int ERROR_PIPE_NOT_CONNECTED = 233;
+   int ERROR_PIPE_CONNECTED = 535;
+   int ERROR_IO_PENDING = 997;
+
+   int FILE_ATTRIBUTE_NORMAL = 0x00000080;
+   int FILE_FLAG_OVERLAPPED = 0x40000000;
+   int FILE_SHARE_READ = 0x00000001;
+   int FILE_SHARE_WRITE = 0x00000002;
+
+   int GENERIC_READ = 0x80000000;
+   int GENERIC_WRITE = 0x40000000;
+
+   int OPEN_EXISTING = 3;
+
+   int STATUS_PENDING = 0x00000103;
+   int STILL_ACTIVE = STATUS_PENDING;
+
+   int STARTF_USESTDHANDLES = 0x100;
+
+   HANDLE INVALID_HANDLE_VALUE = new HANDLE(Pointer.createConstant(Pointer.SIZE == 8 ? -1 : 0xFFFFFFFFL));
+
+   class HANDLE extends PointerType
+   {
+      public HANDLE() {
+      }
+
+      public HANDLE(Pointer p) {
+         setPointer(p);
+      }
+
+      @Override
+      public Object fromNative(Object nativeValue, FromNativeContext context) {
+         Object o = super.fromNative(nativeValue, context);
+         if (INVALID_HANDLE_VALUE.equals(o)) {
+            return INVALID_HANDLE_VALUE;
+         }
+         return o;
+      }
+   }
+
+   static class WORD extends IntegerType
+   {
+      public static final int SIZE = 2;
+
+      public WORD() {
+         this(0);
+      }
+
+      public WORD(long value) {
+         super(SIZE, value, true);
+      }
+   }
+
+   static class DWORD extends IntegerType
+   {
+      public static final int SIZE = 4;
+
+      public DWORD() {
+         this(0);
+      }
+
+      public DWORD(long value) {
+         super(SIZE, value, true);
+      }
+   }
+
+   static class ULONG_PTR extends IntegerType
+   {
+      public ULONG_PTR() {
+         this(0);
+      }
+
+      public ULONG_PTR(long value) {
+         super(Pointer.SIZE, value, true);
+      }
+
+      public Pointer toPointer() {
+         return Pointer.createConstant(longValue());
+      }
+   }
+
+   static class ULONG_PTRByReference extends ByReference
+   {
+      public ULONG_PTRByReference() {
+         this(new ULONG_PTR(0));
+      }
+      public ULONG_PTRByReference(ULONG_PTR value) {
+         super(Pointer.SIZE);
+         setValue(value);
+      }
+      public void setValue(ULONG_PTR value) {
+         if (Pointer.SIZE == 4) {
+            getPointer().setInt(0, value.intValue());
+         }
+         else {
+            getPointer().setLong(0, value.longValue());
+         }
+      }
+      public ULONG_PTR getValue() {
+         return new ULONG_PTR(Pointer.SIZE == 4
+                              ? getPointer().getInt(0)
+                              : getPointer().getLong(0));
+      }
+   }
+
+   class SECURITY_ATTRIBUTES extends Structure
+   {
+      public DWORD dwLength;
+      public Pointer lpSecurityDescriptor;
+      public boolean bInheritHandle;
+
+      @Override
+      protected List getFieldOrder() {
+         return Arrays.asList(new String[] { "dwLength", "lpSecurityDescriptor", "bInheritHandle" });
+      }
+   }
+
+   class STARTUPINFO extends Structure
+   {
+      public DWORD cb;
+      public String lpReserved;
+      public String lpDesktop;
+      public String lpTitle;
+      public DWORD dwX;
+      public DWORD dwY;
+      public DWORD dwXSize;
+      public DWORD dwYSize;
+      public DWORD dwXCountChars;
+      public DWORD dwYCountChars;
+      public DWORD dwFillAttribute;
+      public int dwFlags;
+      public WORD wShowWindow;
+      public WORD cbReserved2;
+      public ByteByReference lpReserved2;
+      public HANDLE hStdInput;
+      public HANDLE hStdOutput;
+      public HANDLE hStdError;
+
+      @Override
+      protected List getFieldOrder() {
+         return Arrays.asList(new String[] {
+                  "cb", "lpReserved", "lpDesktop", "lpTitle", "dwX", "dwY",
+                  "dwXSize", "dwYSize", "dwXCountChars", "dwYCountChars",
+                  "dwFillAttribute", "dwFlags", "wShowWindow", "cbReserved2",
+                  "lpReserved2", "hStdInput", "hStdOutput", "hStdError" });
+      }
+
+      public STARTUPINFO() {
+         cb = new DWORD(size());
+      }
+   }
+
+   class PROCESS_INFORMATION extends Structure
+   {
+      public HANDLE hProcess;
+      public HANDLE hThread;
+      public DWORD dwProcessId;
+      public DWORD dwThreadId;
+
+      protected List getFieldOrder() {
+         return Arrays.asList(new String[] { "hProcess", "hThread", "dwProcessId", "dwThreadId" });
+      }
+   }
+}

--- a/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
@@ -29,14 +29,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.sun.jna.Native;
-import com.sun.jna.platform.win32.BaseTSD.ULONG_PTR;
-import com.sun.jna.platform.win32.BaseTSD.ULONG_PTRByReference;
-import com.sun.jna.platform.win32.WinNT;
-import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.zaxxer.nuprocess.NuProcess;
 import com.zaxxer.nuprocess.windows.WindowsProcess.PipeBundle;
+import com.zaxxer.nuprocess.windows.NuWinNT.HANDLE;
+import com.zaxxer.nuprocess.windows.NuWinNT.ULONG_PTR;
+import com.zaxxer.nuprocess.windows.NuWinNT.ULONG_PTRByReference;
 
 public final class ProcessCompletions implements Runnable
 {
@@ -230,7 +229,7 @@ public final class ProcessCompletions implements Runnable
       }
 
       if (NuKernel32.WriteFile(stdinPipe.pipeHandle, stdinPipe.bufferPointer, 0, null, stdinPipe.overlapped) == 0
-            && Native.getLastError() != WinNT.ERROR_IO_PENDING) {
+            && Native.getLastError() != NuWinNT.ERROR_IO_PENDING) {
          process.stdinClose();
       }
    }
@@ -245,11 +244,11 @@ public final class ProcessCompletions implements Runnable
       if (NuKernel32.ReadFile(pipe.pipeHandle, pipe.bufferPointer.share(pipe.buffer.position()), pipe.buffer.remaining(), null, pipe.overlapped) == 0) {
          int lastError = Native.getLastError();
          switch (lastError) {
-         case WinNT.ERROR_SUCCESS:
-         case WinNT.ERROR_IO_PENDING:
+         case NuWinNT.ERROR_SUCCESS:
+         case NuWinNT.ERROR_IO_PENDING:
             break;
-         case WinNT.ERROR_BROKEN_PIPE:
-         case WinNT.ERROR_PIPE_NOT_CONNECTED:
+         case NuWinNT.ERROR_BROKEN_PIPE:
+         case NuWinNT.ERROR_PIPE_NOT_CONNECTED:
             if (stdX == STDOUT) {
                process.readStdout(-1 /*closed*/);
             }
@@ -306,7 +305,7 @@ public final class ProcessCompletions implements Runnable
       Iterator<WindowsProcess> iterator = deadPool.iterator();
       while (iterator.hasNext()) {
          WindowsProcess process = iterator.next();
-         if (NuKernel32.GetExitCodeProcess(process.getPid(), exitCode) && exitCode.getValue() != WinNT.STILL_ACTIVE) {
+         if (NuKernel32.GetExitCodeProcess(process.getPid(), exitCode) && exitCode.getValue() != NuWinNT.STILL_ACTIVE) {
             iterator.remove();
             process.onExit(exitCode.getValue());
          }
@@ -320,7 +319,7 @@ public final class ProcessCompletions implements Runnable
       completionKeyToProcessMap.remove(process.getStderrPipe().ioCompletionKey);
 
       IntByReference exitCode = new IntByReference();
-      if (NuKernel32.GetExitCodeProcess(process.getPid(), exitCode) && exitCode.getValue() != WinNT.STILL_ACTIVE) {
+      if (NuKernel32.GetExitCodeProcess(process.getPid(), exitCode) && exitCode.getValue() != NuWinNT.STILL_ACTIVE) {
          process.onExit(exitCode.getValue());
       }
       else {
@@ -330,7 +329,7 @@ public final class ProcessCompletions implements Runnable
 
    private void initCompletionPort()
    {
-      ioCompletionPort = NuKernel32.CreateIoCompletionPort(WinNT.INVALID_HANDLE_VALUE, null, new ULONG_PTR(0), WindowsProcess.PROCESSOR_THREADS);
+      ioCompletionPort = NuKernel32.CreateIoCompletionPort(NuWinNT.INVALID_HANDLE_VALUE, null, new ULONG_PTR(0), WindowsProcess.PROCESSOR_THREADS);
       if (ioCompletionPort == null) {
          throw new RuntimeException("CreateIoCompletionPort() failed, error code: " + Native.getLastError());
       }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -36,17 +36,15 @@ import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
-import com.sun.jna.platform.win32.WinBase;
-import com.sun.jna.platform.win32.WinBase.PROCESS_INFORMATION;
-import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
-import com.sun.jna.platform.win32.WinBase.STARTUPINFO;
-import com.sun.jna.platform.win32.WinDef.DWORD;
-import com.sun.jna.platform.win32.WinNT;
-import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.zaxxer.nuprocess.NuProcess;
 import com.zaxxer.nuprocess.NuProcessHandler;
 import com.zaxxer.nuprocess.internal.UnsafeHelper;
 import com.zaxxer.nuprocess.windows.NuKernel32.OVERLAPPED;
+import com.zaxxer.nuprocess.windows.NuWinNT.DWORD;
+import com.zaxxer.nuprocess.windows.NuWinNT.HANDLE;
+import com.zaxxer.nuprocess.windows.NuWinNT.PROCESS_INFORMATION;
+import com.zaxxer.nuprocess.windows.NuWinNT.SECURITY_ATTRIBUTES;
+import com.zaxxer.nuprocess.windows.NuWinNT.STARTUPINFO;
 
 /**
  * @author Brett Wooldridge
@@ -161,7 +159,7 @@ public final class WindowsProcess implements NuProcess
    @Override
    public void wantWrite()
    {
-      if (hStdinWidow != null && !WinBase.INVALID_HANDLE_VALUE.getPointer().equals(hStdinWidow.getPointer())) {
+      if (hStdinWidow != null && !NuWinNT.INVALID_HANDLE_VALUE.getPointer().equals(hStdinWidow.getPointer())) {
          userWantsWrite.set(true);
          myProcessor.wantWrite(this);
       }
@@ -171,7 +169,7 @@ public final class WindowsProcess implements NuProcess
    @Override
    public synchronized void writeStdin(ByteBuffer buffer)
    {
-      if (hStdinWidow != null && !WinBase.INVALID_HANDLE_VALUE.getPointer().equals(hStdinWidow.getPointer())) {
+      if (hStdinWidow != null && !NuWinNT.INVALID_HANDLE_VALUE.getPointer().equals(hStdinWidow.getPointer())) {
          pendingWrites.add(buffer);
          if (!writePending) {
             myProcessor.wantWrite(this);
@@ -238,11 +236,11 @@ public final class WindowsProcess implements NuProcess
          startupInfo.hStdInput = hStdinWidow;
          startupInfo.hStdError = hStderrWidow;
          startupInfo.hStdOutput = hStdoutWidow;
-         startupInfo.dwFlags = WinNT.STARTF_USESTDHANDLES;
+         startupInfo.dwFlags = NuWinNT.STARTF_USESTDHANDLES;
 
          processInfo = new PROCESS_INFORMATION();
 
-         DWORD dwCreationFlags = new DWORD(WinNT.CREATE_NO_WINDOW | WinNT.CREATE_UNICODE_ENVIRONMENT | WinNT.CREATE_SUSPENDED);
+         DWORD dwCreationFlags = new DWORD(NuWinNT.CREATE_NO_WINDOW | NuWinNT.CREATE_UNICODE_ENVIRONMENT | NuWinNT.CREATE_SUSPENDED);
          char[] cwdChars = (cwd != null) ? Native.toCharArray(cwd.toAbsolutePath().toString()) : null;
          if (!NuKernel32.CreateProcessW(null, getCommandLine(commands), null /*lpProcessAttributes*/, null /*lpThreadAttributes*/, true /*bInheritHandles*/,
                                         dwCreationFlags, env, cwdChars, startupInfo, processInfo)) {
@@ -518,8 +516,8 @@ public final class WindowsProcess implements NuProcess
                                                  0 /*nDefaultTimeOut*/, sattr);
       checkHandleValidity(hStdoutWidow);
 
-      HANDLE stdoutHandle = NuKernel32.CreateFile(pipeName, WinNT.GENERIC_READ, WinNT.FILE_SHARE_READ, null, WinNT.OPEN_EXISTING, WinNT.FILE_ATTRIBUTE_NORMAL
-            | WinNT.FILE_FLAG_OVERLAPPED, null /*hTemplateFile*/);
+      HANDLE stdoutHandle = NuKernel32.CreateFile(pipeName, NuWinNT.GENERIC_READ, NuWinNT.FILE_SHARE_READ, null, NuWinNT.OPEN_EXISTING, NuWinNT.FILE_ATTRIBUTE_NORMAL
+            | NuWinNT.FILE_FLAG_OVERLAPPED, null /*hTemplateFile*/);
       checkHandleValidity(stdoutHandle);
       stdoutPipe = new PipeBundle(stdoutHandle, ioCompletionKey);
       checkPipeConnected(NuKernel32.ConnectNamedPipe(hStdoutWidow, null));
@@ -531,8 +529,8 @@ public final class WindowsProcess implements NuProcess
                                                  0 /*nDefaultTimeOut*/, sattr);
       checkHandleValidity(hStderrWidow);
 
-      HANDLE stderrHandle = NuKernel32.CreateFile(pipeName, WinNT.GENERIC_READ, WinNT.FILE_SHARE_READ, null, WinNT.OPEN_EXISTING, WinNT.FILE_ATTRIBUTE_NORMAL
-            | WinNT.FILE_FLAG_OVERLAPPED, null /*hTemplateFile*/);
+      HANDLE stderrHandle = NuKernel32.CreateFile(pipeName, NuWinNT.GENERIC_READ, NuWinNT.FILE_SHARE_READ, null, NuWinNT.OPEN_EXISTING, NuWinNT.FILE_ATTRIBUTE_NORMAL
+            | NuWinNT.FILE_FLAG_OVERLAPPED, null /*hTemplateFile*/);
       checkHandleValidity(stderrHandle);
       stderrPipe = new PipeBundle(stderrHandle, ioCompletionKey);
       checkPipeConnected(NuKernel32.ConnectNamedPipe(hStderrWidow, null));
@@ -544,8 +542,8 @@ public final class WindowsProcess implements NuProcess
                                                 0 /*nDefaultTimeOut*/, sattr);
       checkHandleValidity(hStdinWidow);
 
-      HANDLE stdinHandle = NuKernel32.CreateFile(pipeName, WinNT.GENERIC_WRITE, WinNT.FILE_SHARE_WRITE, null, WinNT.OPEN_EXISTING, WinNT.FILE_ATTRIBUTE_NORMAL
-            | WinNT.FILE_FLAG_OVERLAPPED, null /*hTemplateFile*/);
+      HANDLE stdinHandle = NuKernel32.CreateFile(pipeName, NuWinNT.GENERIC_WRITE, NuWinNT.FILE_SHARE_WRITE, null, NuWinNT.OPEN_EXISTING, NuWinNT.FILE_ATTRIBUTE_NORMAL
+            | NuWinNT.FILE_FLAG_OVERLAPPED, null /*hTemplateFile*/);
       checkHandleValidity(stdinHandle);
       stdinPipe = new PipeBundle(stdinHandle, ioCompletionKey);
       checkPipeConnected(NuKernel32.ConnectNamedPipe(hStdinWidow, null));
@@ -661,7 +659,7 @@ public final class WindowsProcess implements NuProcess
 
    private void checkHandleValidity(HANDLE handle)
    {
-      if (WinBase.INVALID_HANDLE_VALUE.getPointer().equals(handle)) {
+      if (NuWinNT.INVALID_HANDLE_VALUE.getPointer().equals(handle)) {
          throw new RuntimeException("Unable to create pipe, error " + Native.getLastError());
       }
    }
@@ -669,7 +667,7 @@ public final class WindowsProcess implements NuProcess
    private void checkPipeConnected(int status)
    {
       int lastError;
-      if (status == 0 && ((lastError = Native.getLastError()) != WinNT.ERROR_PIPE_CONNECTED)) {
+      if (status == 0 && ((lastError = Native.getLastError()) != NuWinNT.ERROR_PIPE_CONNECTED)) {
          throw new RuntimeException("Unable to connect pipe, error: " + lastError);
       }
    }


### PR DESCRIPTION
When I started testing on Win32, I noticed `NuProcess` depends on `jna-platform` only for Win32 (to pull in a few constants and structures).

`NuProcess` is a svelte 90 KiB in size once built, so it seems a pity to pull in the 1.4MiB `jna-platform` just for Win32 support.

This removes the dependency in favor of a small `NuWinNT` class which contains the constants and structures needed by `NuProcess`'s Win32 support.