### PR TITLE
Fix Win32 arg escaping for args with backslashes, concurrent named pipe access

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsCreateProcessEscape.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsCreateProcessEscape.java
@@ -1,0 +1,110 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org/>
+
+package com.zaxxer.nuprocess.windows;
+
+/**
+ * Helps quote arguments when launching a process on Windows.
+ *
+ * Unix's process spawning syscall accepts an array of arguments, but Windows'
+ * equivalent accepts a single string and splits the strings according to some
+ * different rules.
+ */
+class WindowsCreateProcessEscape {
+  private WindowsCreateProcessEscape() {}
+
+  /**
+   * Same as {@link #quote(String)} except appends to a {@code StringBuilder}.
+   */
+  public static void quote(StringBuilder buf, String arg) {
+    if (!mightNeedQuotes(arg)) {
+      buf.append(arg);
+      return;
+    }
+    buf.append('"');
+
+    // The length of the current run of backslashes.
+    int nPending = 0;
+
+    for (int i = 0; i < arg.length(); i++) {
+      char c = arg.charAt(i);
+
+      if (c == '\\') {
+        nPending++;
+      } else {
+        if (c == '"') {
+          // Escape all the backslashes we've collected up till now.
+          for (int j = 0; j < nPending; j++) {
+            buf.append('\\');
+          }
+          // Escape the quote.
+          buf.append('\\');
+        }
+        nPending = 0;
+      }
+
+      buf.append(c);
+    }
+
+    // Escape all the backslashes that appear before the final closing quote.
+    for (int j = 0; j < nPending; j++) {
+      buf.append('\\');
+    }
+
+    buf.append('"');
+  }
+
+  /**
+   * Given a string X, this function returns a string that, when passed through
+   * the Windows implementation of Java's {@link Runtime#exec(String[])} or
+   * {@link java.lang.ProcessBuilder}, will appear to the spawned process as X.
+   *
+   * @param arg
+   *    The argument to quote.
+   *
+   * @return
+   *    The quote version of 'arg'.
+   */
+  public static String quote(String arg) {
+    StringBuilder buf = new StringBuilder(2 + arg.length() * 2);
+    quote(buf, arg);
+    return buf.toString();
+  }
+
+  private static boolean mightNeedQuotes(String arg) {
+    if (arg.length() == 0) {
+      return true;
+    }
+
+    for (int i = 0; i < arg.length(); i++) {
+      char c = arg.charAt(i);
+      if (c == '"' || c == ' ' || c == '\t') {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -62,6 +63,7 @@ public final class WindowsProcess implements NuProcess
    private static final ProcessCompletions[] processors;
    private static int processorRoundRobin;
 
+   private static final String namedPipePathPrefix;
    private static final AtomicInteger namedPipeCounter;
 
    private volatile ProcessCompletions myProcessor;
@@ -93,6 +95,7 @@ public final class WindowsProcess implements NuProcess
    private PROCESS_INFORMATION processInfo;
 
    static {
+      namedPipePathPrefix = "\\\\.\\pipe\\NuProcess-" + UUID.randomUUID().toString() + "-";
       namedPipeCounter = new AtomicInteger(100);
 
       IS_SOFTEXIT_DETECTION = Boolean.valueOf(System.getProperty("com.zaxxer.nuprocess.softExitDetection", "true"));
@@ -513,7 +516,7 @@ public final class WindowsProcess implements NuProcess
 
       // ################ STDOUT PIPE ################
       long ioCompletionKey = namedPipeCounter.getAndIncrement();
-      WString pipeName = new WString("\\\\.\\pipe\\NuProcess" + ioCompletionKey);
+      WString pipeName = new WString(namedPipePathPrefix + ioCompletionKey);
       hStdoutWidow = NuKernel32.CreateNamedPipeW(pipeName, NuKernel32.PIPE_ACCESS_INBOUND, 0 /*dwPipeMode*/, 1 /*nMaxInstances*/, BUFFER_SIZE, BUFFER_SIZE,
                                                  0 /*nDefaultTimeOut*/, sattr);
       checkHandleValidity(hStdoutWidow);
@@ -526,7 +529,7 @@ public final class WindowsProcess implements NuProcess
 
       // ################ STDERR PIPE ################
       ioCompletionKey = namedPipeCounter.getAndIncrement();
-      pipeName = new WString("\\\\.\\pipe\\NuProcess" + ioCompletionKey);
+      pipeName = new WString(namedPipePathPrefix + ioCompletionKey);
       hStderrWidow = NuKernel32.CreateNamedPipeW(pipeName, NuKernel32.PIPE_ACCESS_INBOUND, 0 /*dwPipeMode*/, 1 /*nMaxInstances*/, BUFFER_SIZE, BUFFER_SIZE,
                                                  0 /*nDefaultTimeOut*/, sattr);
       checkHandleValidity(hStderrWidow);
@@ -539,7 +542,7 @@ public final class WindowsProcess implements NuProcess
 
       // ################ STDIN PIPE ################
       ioCompletionKey = namedPipeCounter.getAndIncrement();
-      pipeName = new WString("\\\\.\\pipe\\NuProcess" + ioCompletionKey);
+      pipeName = new WString(namedPipePathPrefix + ioCompletionKey);
       hStdinWidow = NuKernel32.CreateNamedPipeW(pipeName, NuKernel32.PIPE_ACCESS_OUTBOUND, 0 /*dwPipeMode*/, 1 /*nMaxInstances*/, BUFFER_SIZE, BUFFER_SIZE,
                                                 0 /*nDefaultTimeOut*/, sattr);
       checkHandleValidity(hStdinWidow);

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -614,31 +614,14 @@ public final class WindowsProcess implements NuProcess
    private char[] getCommandLine(List<String> commands)
    {
       StringBuilder sb = new StringBuilder();
-      if (commands.get(0).contains(" ") && !commands.get(0).startsWith("\"") && !commands.get(0).endsWith("\"")) {
-         commands.set(0, "\"" + commands.get(0).replaceAll("\\\"", "\\\"") + "\"");
+      for (String command : commands) {
+         // It's OK to apply CreateProcess escaping to even the first item in the commands
+         // list (the path to execute). Since Windows paths cannot contain double-quotes
+         // (really!), the logic in WindowsCreateProcessEscape.quote() will either do nothing
+         // or simply add double-quotes around the path.
+         WindowsCreateProcessEscape.quote(sb, command);
       }
-
-      Iterator<String> iterator = commands.iterator();
-      sb.append(iterator.next()).append(' '); // skip the executable itself
-      while (iterator.hasNext()) {
-         String s = iterator.next();
-         if (s.contains(" ")) {
-            sb.append('"').append(s).append('"');
-         }
-         else {
-            sb.append(s);
-         }
-
-         sb.append(' ');
-      }
-
-      if (sb.length() > 0) {
-         sb.setLength(sb.length() - 1);
-      }
-
-      sb.append((char) 0);
-
-      return sb.toString().toCharArray();
+      return Native.toCharArray(sb.toString());
    }
 
    private char[] getEnvironment(String[] environment)


### PR DESCRIPTION
During testing of `NuProcess` on Win32, I found a few nasty bugs:

1. The argument escaping logic didn't handle arguments with `"` and/or `\` in them (the logic to do this correctly is Byzantine and awful)
2. The named pipes opened in `WindowsProcess` used identifiers which were unique only to the process, so if two JVMs started up and used `NuProcess` at the same time, they would collide and fail to open their named pipes with `ERROR_INVALID_HANDLE`
3. If opening the named pipes failed, we would (correctly) throw an exception, but then NPE cleaning up the `WindowsProcess`

I brought in the command-line escaper logic used by Buck (a public domain implementation) to fix 1) above, and just fixed the other issues.