### PR TITLE
Fix regression with fast exiting processes on Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-junit</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/zaxxer/nuprocess/linux/ProcessEpoll.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/ProcessEpoll.java
@@ -227,6 +227,11 @@ class ProcessEpoll extends BaseEventProcessor<LinuxProcess>
       //        linuxProcess.close(linuxProcess.getStdout());
       //        linuxProcess.close(linuxProcess.getStderr());
 
+      if (linuxProcess.cleanlyExitedBeforeProcess.get()) {
+         linuxProcess.onExit(0);
+         return;
+      }
+
       IntByReference ret = new IntByReference();
       int rc = LibC.waitpid(linuxProcess.getPid(), ret, LibC.WNOHANG);
 

--- a/src/test/java/com/zaxxer/nuprocess/FastExitingProcessTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/FastExitingProcessTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 Ben Hamilton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.nuprocess;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import com.sun.jna.Platform;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public class FastExitingProcessTest
+{
+   private static class Handler extends NuAbstractProcessHandler
+   {
+      public final ByteArrayOutputStream stdoutBytes = new ByteArrayOutputStream();
+      public final WritableByteChannel stdoutBytesChannel = Channels.newChannel(stdoutBytes);
+      public int exitCode = -1;
+      public Exception stdoutException;
+
+      @Override
+      public void onExit(int exitCode) {
+         this.exitCode = exitCode;
+      }
+
+      @Override
+      public void onStdout(ByteBuffer buffer, boolean closed) {
+         try {
+            stdoutBytesChannel.write(buffer);
+         } catch (Exception e) {
+            stdoutException = e;
+         }
+      }
+   }
+
+   @Test
+   public void whenProcessWritesToStdoutThenExitsThenHandlerReceivesOutput() throws Exception {
+      Handler handler = new Handler();
+      NuProcess process;
+      if (Platform.isWindows()) {
+         process = new NuProcessBuilder(handler, "cmd.exe", "/c", "echo", "Hello world!").start();
+      } else {
+         process = new NuProcessBuilder(handler, "echo", "Hello world!").start();
+      }
+      int retVal = process.waitFor(Long.MAX_VALUE, TimeUnit.SECONDS);
+      assertThat("Process should exit cleanly", retVal, equalTo(0));
+      assertThat("Process callback should indicate clean exit", handler.exitCode, equalTo(0));
+      assertThat("No exceptions thrown writing to stdout", handler.stdoutException, is(nullValue()));
+      assertThat(
+            "Stdout should contain expected output",
+            handler.stdoutBytes.toString("UTF-8"),
+            equalTo(String.format("Hello world!%n")));
+   }
+}


### PR DESCRIPTION
#35 caused a regression on Linux where fast-exiting processes would eagerly close stdout and stderr, so `epoll()` would never have a chance to read the data the process sent before exiting.

This adds a test to reproduce the issue (I pulled in hamcrest, mea culpa) and fixes the problem for processes which exit cleanly.

For processes which do not exit cleanly, I'm not sure what we want to do. We want to get stdout and stderr for processes which do launch but then exit quickly with a non-zero error code after writing to stdout/stderr, but if we also want to keep the semantics of returning `null` from `NuProcessBuilder.start()` in that case, it'll be pretty tricky.