### PR TITLE
Add "soft" close support to NuProcess.closeStdin()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class ProcessHandler extends NuAbstractProcessHandler {
       System.out.println(new String(bytes));
 
       // We're done, so closing STDIN will cause the "cat" process to exit
-      nuProcess.closeStdin();
+      nuProcess.closeStdin(true);
 }
 ```
 
@@ -113,7 +113,7 @@ class ProcessHandler extends NuAbstractProcessHandler {
       System.out.println(new String(bytes));
 
       // We're done, so closing STDIN will cause the "cat" process to exit
-      nuProcess.closeStdin();
+      nuProcess.closeStdin(true);
 }
 ```
 

--- a/src/example/java/com/zaxxer/nuprocess/example/NuSchool.java
+++ b/src/example/java/com/zaxxer/nuprocess/example/NuSchool.java
@@ -138,7 +138,7 @@ public class NuSchool
 
             if (size == LIMIT || closed)
             {
-                nuProcess.closeStdin();
+                nuProcess.closeStdin(true);
             }
         }
 

--- a/src/example/java/com/zaxxer/nuprocess/example/SshExample.java
+++ b/src/example/java/com/zaxxer/nuprocess/example/SshExample.java
@@ -124,7 +124,7 @@ public class SshExample
 
             // nuProcess.wantWrite();
             // We're done, so closing STDIN will cause the "cat" process to exit
-            //nuProcess.closeStdin();
+            //nuProcess.closeStdin(true);
         }
 
         @Override

--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -97,19 +97,24 @@ public interface NuProcess
 
    /**
     * This method is used to close the STDIN pipe between the Java process and
-    * the spawned process. The STDIN pipe is immediately closed regardless of
+    * the spawned process.
+    * <p>
+    * If {@code force} is {@code true}, the STDIN pipe is immediately closed regardless of
     * pending unwritten data, and even data that has been written into the pipe
     * will be immediately discarded.
+    * <p>
+    * Otherwise, STDIN will be closed only after all pending writes
+    * have completed.
     */
-   void closeStdin();
+   void closeStdin(boolean force);
 
    /**
     * This method is most useful in combination with {@link #writeStdin}. This
     * method returns true if there is outstanding data to be written to the
     * stdin stream, and false if there are no pending writes.
-    * 
-    * @return <code>true</code> if there are pending writes, <code>false</code>
-    *         otherwise
+    *
+    * @return <code>true</code> if there are pending writes or STDIN is pending
+    *         close, <code>false</code> otherwise
     */
    boolean hasPendingWrites();
 

--- a/src/test/java/com/zaxxer/nuprocess/DirectWrite.java
+++ b/src/test/java/com/zaxxer/nuprocess/DirectWrite.java
@@ -84,7 +84,7 @@ public class DirectWrite
 
       Thread.sleep(500);
 
-      nuProcess.closeStdin();
+      nuProcess.closeStdin(true);
       nuProcess.waitFor(0, TimeUnit.SECONDS);
       Assert.assertEquals("Count did not match", 14, count.get());
    }
@@ -114,7 +114,7 @@ public class DirectWrite
 
       Thread.sleep(500);
 
-      nuProcess.closeStdin();
+      nuProcess.closeStdin(true);
       nuProcess.waitFor(0, TimeUnit.SECONDS);
       Assert.assertEquals("Count did not match", 14000, count.get());
    }
@@ -144,7 +144,7 @@ public class DirectWrite
          buffer.get(chars);
          result = new String(chars);
          System.out.println("Read: " + result);
-         nuProcess.closeStdin();
+         nuProcess.closeStdin(true);
       }
    }
 
@@ -182,7 +182,7 @@ public class DirectWrite
          System.out.println("Reading.  Current checksum " + checksum2);
          if (checksum2 == checksum) {
             System.out.println("Checksums matched, exiting.");
-            nuProcess.closeStdin();
+            nuProcess.closeStdin(true);
          }
       }
    }

--- a/src/test/java/com/zaxxer/nuprocess/ThreadedTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/ThreadedTest.java
@@ -155,7 +155,7 @@ public class ThreadedTest
          readAdler32.update(bytes);
 
          if (size == LIMIT)
-            nuProcess.closeStdin();
+            nuProcess.closeStdin(true);
       }
 
       @Override


### PR DESCRIPTION
Previously, there was no good way to write data to `stdin` of a `NuProcess` then close it once all the writes completed.

`CatTest` and a few examples use the assumption that the same number of bytes will be written to `stdout`, but that's not true for all processes the user might want to execute.

This diff changes `NuProcess.closeStdin()` to accept a `boolean force` parameter. If `true`, we use the old behavior of forcibly closing stdin and dropping all data pending write. If `false`, we enqueue a "tombstone" buffer to `pendingWrites` to indicate we should close stdin once that position in the queue is reached.

Once I did this, I found a few places where we were assuming `NuProcess.getStdin().get()` was always returning a valid fd. Since it's more common for it to return -1 now, I hardened the places where we assumed it did not. (This is still a little racy: it's possible to call `NuProcess.getStdin().get()` on one thread, then afterwards call `NuProcess.getStdin().set(-1); LibC.close(oldFd);` on another.)

Finally, I added a minor perf improvement to `BasePosixProcess`: after invoking `NuProcessHandler.onStdinReady()`, we'll immediately try to write the bytes to the process's `stdin` fd if there's any availability instead of waiting until the next time `kqueue()` / `epoll()` fires the stdin ready notification. (I think we can't currently make this improvement on Windows, since we only have one outstanding overlapped I/O at a time there.)