### PR TITLE
Enable/disable command line quoting on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <com.zaxxer.nuprocess.enableWindowsCmdArgQuoting>false</com.zaxxer.nuprocess.enableWindowsCmdArgQuoting>
+                        <buildDirectory>${project.build.directory}</buildDirectory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -54,6 +54,7 @@ public final class WindowsProcess implements NuProcess
    public static final int PROCESSOR_THREADS;
 
    private static final boolean IS_SOFTEXIT_DETECTION;
+   private static final boolean IS_ENABLE_WINDOWS_CMD_ARG_QUOTING;
 
    private static final int BUFFER_SIZE = 65536;
 
@@ -96,6 +97,7 @@ public final class WindowsProcess implements NuProcess
       namedPipeCounter = new AtomicInteger(100);
 
       IS_SOFTEXIT_DETECTION = Boolean.valueOf(System.getProperty("com.zaxxer.nuprocess.softExitDetection", "true"));
+      IS_ENABLE_WINDOWS_CMD_ARG_QUOTING = Boolean.valueOf(System.getProperty("com.zaxxer.nuprocess.enableWindowsCmdArgQuoting", "true"));
 
       String threads = System.getProperty("com.zaxxer.nuprocess.threads", "auto");
       if ("auto".equals(threads)) {
@@ -617,8 +619,21 @@ public final class WindowsProcess implements NuProcess
          // list (the path to execute). Since Windows paths cannot contain double-quotes
          // (really!), the logic in WindowsCreateProcessEscape.quote() will either do nothing
          // or simply add double-quotes around the path.
-         WindowsCreateProcessEscape.quote(sb, command);
+         if (IS_ENABLE_WINDOWS_CMD_ARG_QUOTING) {
+            WindowsCreateProcessEscape.quote(sb, command);
+         } else {
+            sb.append(command);
+            sb.append(' ');
+         }
       }
+
+      if (!IS_ENABLE_WINDOWS_CMD_ARG_QUOTING) {
+          if (sb.length() > 0) {
+              sb.setLength(sb.length() - 1);
+          }
+          sb.append('\0');
+      }
+
       return Native.toCharArray(sb.toString());
    }
 


### PR DESCRIPTION
Added com.zaxxer.nuprocess.enableWindowsCmdArgQuoting system property to enable/disable command line argument quoting on Windows.

Also changed the pom to disable quoting by default so that the tests would pass on Windows.

Copied the non-quoting code from NuProcess 0.9.7. Not sure if the '\0' is required as terminating char for command lines, but it seemed that without it JNA Kernel32Test garbled the "echo" output. Better leave it then.