### PR TITLE
Fix race condition if one thread closes an FD while another is about to read/write

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/ReferenceCountedFileDescriptor.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/ReferenceCountedFileDescriptor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 Ben Hamilton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.zaxxer.nuprocess.internal;
+
+import com.sun.jna.LastErrorException;
+
+/**
+ * Encapsulates a file descriptor plus a reference count to ensure close requests
+ * only close the file descriptor once the last reference to the file descriptor
+ * is released.
+ *
+ * If not explicitly closed, the file descriptor will be closed when
+ * this object is finalized.
+ */
+public class ReferenceCountedFileDescriptor {
+   private int fd;
+   private int fdRefCount;
+   private boolean closePending;
+
+   public ReferenceCountedFileDescriptor(int fd) {
+      this.fd = fd;
+      this.fdRefCount = 0;
+      this.closePending = false;
+   }
+
+   protected void finalize() {
+      close();
+   }
+
+   public synchronized int acquire() {
+      fdRefCount++;
+      return fd;
+   }
+
+   public synchronized void release() {
+      fdRefCount--;
+      if (fdRefCount == 0 && closePending && fd != -1) {
+         doClose();
+      }
+   }
+
+   public synchronized void close() {
+      if (fd == -1 || closePending) {
+         return;
+      }
+
+      if (fdRefCount == 0) {
+         doClose();
+      } else {
+         // Another thread has the FD. We'll close it when they release the reference.
+         closePending = true;
+      }
+   }
+
+   private void doClose() {
+      try {
+         LibC.close(fd);
+         fd = -1;
+      } catch (LastErrorException e) {
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/src/main/java/com/zaxxer/nuprocess/osx/OsxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/OsxProcess.java
@@ -46,14 +46,6 @@ public class OsxProcess extends BasePosixProcess
       super(processListener);
    }
 
-   void stdinClose()
-   {
-      int fd = stdin.getAndSet(-1);
-      if (fd != -1) {
-         LibC.close(fd);
-      }
-   }
-
    @Override
    protected short getSpawnFlags()
    {

--- a/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
@@ -87,19 +87,37 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
 
       pidToProcessMap.put(pid, process);
 
-      // We don't use the processEvents array here, since this method is not
-      // called on the event processor thread.
-      Kevent[] events = (Kevent[]) new Kevent().toArray(4);
-      // Listen for process exit (one-shot event)
-      events[0].EV_SET((long) pid, Kevent.EVFILT_PROC, Kevent.EV_ADD | Kevent.EV_RECEIPT | Kevent.EV_ONESHOT,
-                       Kevent.NOTE_EXIT | Kevent.NOTE_EXITSTATUS | Kevent.NOTE_REAP, 0l, pidPointer);
-      // Listen for stdout and stderr data availability (events deleted automatically when file descriptors closed)
-      events[1].EV_SET(process.getStdout().get(), Kevent.EVFILT_READ, Kevent.EV_ADD | Kevent.EV_RECEIPT, 0, 0l, pidPointer);
-      events[2].EV_SET(process.getStderr().get(), Kevent.EVFILT_READ, Kevent.EV_ADD | Kevent.EV_RECEIPT, 0, 0l, pidPointer);
-      // Listen for stdin data availability (initially disabled until user wants read, deleted automatically when file descriptor closed)
-      events[3].EV_SET(process.getStdin().get(), Kevent.EVFILT_WRITE, Kevent.EV_ADD | Kevent.EV_DISABLE | Kevent.EV_RECEIPT, 0, 0l, pidPointer);
+      Integer stdinFd = null;
+      Integer stdoutFd = null;
+      Integer stderrFd = null;
+      try {
+         stdinFd = process.getStdin().acquire();
+         stdoutFd = process.getStdout().acquire();
+         stderrFd = process.getStderr().acquire();
+         // We don't use the processEvents array here, since this method is not
+         // called on the event processor thread.
+         Kevent[] events = (Kevent[]) new Kevent().toArray(4);
+         // Listen for process exit (one-shot event)
+         events[0].EV_SET((long) pid, Kevent.EVFILT_PROC, Kevent.EV_ADD | Kevent.EV_RECEIPT | Kevent.EV_ONESHOT,
+                          Kevent.NOTE_EXIT | Kevent.NOTE_EXITSTATUS | Kevent.NOTE_REAP, 0l, pidPointer);
+         // Listen for stdout and stderr data availability (events deleted automatically when file descriptors closed)
+         events[1].EV_SET(stdoutFd, Kevent.EVFILT_READ, Kevent.EV_ADD | Kevent.EV_RECEIPT, 0, 0l, pidPointer);
+         events[2].EV_SET(stderrFd, Kevent.EVFILT_READ, Kevent.EV_ADD | Kevent.EV_RECEIPT, 0, 0l, pidPointer);
+         // Listen for stdin data availability (initially disabled until user wants read, deleted automatically when file descriptor closed)
+         events[3].EV_SET(stdinFd, Kevent.EVFILT_WRITE, Kevent.EV_ADD | Kevent.EV_DISABLE | Kevent.EV_RECEIPT, 0, 0l, pidPointer);
 
-      registerEvents(events, 4);
+         registerEvents(events, 4);
+      } finally {
+         if (stdinFd != null) {
+            process.getStdin().release();
+         }
+         if (stdoutFd != null) {
+            process.getStdout().release();
+         }
+         if (stderrFd != null) {
+            process.getStderr().release();
+         }
+      }
    }
 
    private void registerEvents(Kevent[] keventArray, int numEvents)
@@ -220,38 +238,57 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
       if (filter == Kevent.EVFILT_READ) // stdout/stderr data available to read
       {
          int available = kevent.data.intValue();
-         if (ident == osxProcess.getStdout().get()) {
-            osxProcess.readStdout(available);
-            if ((kevent.flags & Kevent.EV_EOF) != 0) {
-               osxProcess.readStdout(-1);
+         try {
+            int stdoutFd = osxProcess.getStdout().acquire();
+            if (ident == stdoutFd) {
+               osxProcess.readStdout(available, stdoutFd);
+               if ((kevent.flags & Kevent.EV_EOF) != 0) {
+                  osxProcess.readStdout(-1, stdoutFd);
+               }
+               return;
             }
+         } finally {
+            osxProcess.getStdout().release();
          }
-         else if (ident == osxProcess.getStderr().get()) {
-            osxProcess.readStderr(available);
-            if ((kevent.flags & Kevent.EV_EOF) != 0) {
-               osxProcess.readStderr(-1);
+
+         try {
+            int stderrFd = osxProcess.getStderr().acquire();
+            if (ident == stderrFd) {
+               osxProcess.readStderr(available, stderrFd);
+               if ((kevent.flags & Kevent.EV_EOF) != 0) {
+                  osxProcess.readStderr(-1, stderrFd);
+               }
+               return;
             }
+         } finally {
+            osxProcess.getStderr().release();
          }
       }
-      else if (filter == Kevent.EVFILT_WRITE && ident == osxProcess.getStdin().get()) // Room in stdin pipe available to write
+      else if (filter == Kevent.EVFILT_WRITE) // Room in stdin pipe available to write
       {
-         int available = kevent.data.intValue();
-         boolean userWantsMore;
-         if (available > 0) {
-            userWantsMore = osxProcess.writeStdin(available);
-         }
-         else {
-            userWantsMore = true;
-         }
-         int stdinFd = osxProcess.getStdin().get();
-         if (!userWantsMore && stdinFd != -1) {
-            // No more stdin for now. Disable the event.
-            // We could use processEvents here and overwrite just the first entry, but this probably doesn't happen
-            // enough to warrant that optimization.
-            Kevent[] events = (Kevent[]) new Kevent().toArray(1);
-            events[0].EV_SET(osxProcess.getStdin().get(), Kevent.EVFILT_WRITE, Kevent.EV_DISABLE | Kevent.EV_RECEIPT, 0, 0l,
-                             Pointer.createConstant(osxProcess.getPid()));
-            registerEvents(events, 1);
+         try {
+            int stdinFd = osxProcess.getStdin().acquire();
+            if (ident == stdinFd) {
+               int available = kevent.data.intValue();
+               boolean userWantsMore;
+               if (available > 0) {
+                  userWantsMore = osxProcess.writeStdin(available, stdinFd);
+               }
+               else {
+                  userWantsMore = true;
+               }
+               if (!userWantsMore) {
+                  // No more stdin for now. Disable the event.
+                  // We could use processEvents here and overwrite just the first entry, but this probably doesn't happen
+                  // enough to warrant that optimization.
+                  Kevent[] events = (Kevent[]) new Kevent().toArray(1);
+                  events[0].EV_SET(stdinFd, Kevent.EVFILT_WRITE, Kevent.EV_DISABLE | Kevent.EV_RECEIPT, 0, 0l,
+                                   Pointer.createConstant(osxProcess.getPid()));
+                  registerEvents(events, 1);
+               }
+            }
+         } finally {
+            osxProcess.getStdin().release();
          }
       }
       else if ((kevent.fflags & Kevent.NOTE_EXIT) != 0) // process has exited System.gc()
@@ -286,7 +323,7 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
       // drainTo() is known to be atomic for ArrayBlockingQueue
       closeQueue.drainTo(processes);
       for (OsxProcess process : processes) {
-         process.stdinClose();
+         process.getStdin().close();
       }
    }
 
@@ -303,11 +340,15 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
          int numKevents = 0;
          for (int i = 0; i < processes.size(); i++) {
             OsxProcess process = processes.get(i);
-            int fd = process.getStdin().get();
-            if (fd != -1) {
-              kevents[numKevents].EV_SET(fd, Kevent.EVFILT_WRITE, Kevent.EV_ENABLE | Kevent.EV_RECEIPT, 0, 0l,
-                                         Pointer.createConstant(process.getPid()));
-              numKevents++;
+            try {
+               int fd = process.getStdin().acquire();
+               if (fd != -1) {
+                  kevents[numKevents].EV_SET(fd, Kevent.EVFILT_WRITE, Kevent.EV_ENABLE | Kevent.EV_RECEIPT, 0, 0l,
+                                             Pointer.createConstant(process.getPid()));
+                  numKevents++;
+               }
+            } finally {
+               process.getStdin().release();
             }
          }
          registerEvents(kevents, numKevents);


### PR DESCRIPTION
POSIX requires that operations which return a new file descriptor (`open()` / `dup()` / etc.) return the lowest-available descriptor.

This means there's a tricky race in `BasePosixProcess`:

```
Processor Thread (epoll/kevent):
  int stdinFd = stdin.get();
  (gets de-scheduled before calling LibC.write(stdinFd))
Thread 1:
  NuProcess.closeStdin(true)
  LibC.close(stdin.getAndSet(-1))
  (the kernel now marks stdinFd as free to re-use)
Any Thread Except Processor Thread:
  fd = open() (or dup(), etc.)
  (kernel will return the old stdin fd, to which the processor thread is about to write)
Processor Thread:
  (gets rescheduled)
  LibC.write(stdinFd)
  (writes garbage to someone else's open file descriptor)
```

This fixes the race the same way the JRE's own `AbstractPlainSocketImpl` does, by putting a reference count around any read, write, or close operations. We'll delay the close until any pending reads or writes complete.

Currently, `stdout` and `stderr` are serially read and closed on the same thread as far as I can tell, but to future-proof this code, I applied the same fix to all three FDs.

We could also fix this by always requiring `stdin` closing to be "soft", so we ensure it's always closed on the event processor thread (serial with any writes). That could be a less invasive change, so let me know what you prefer.

Tested on OS X with `mvn test`. Haven't gotten to test on Linux yet.
