### PR TITLE
Add getPID() to NuProcess.

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -165,5 +165,5 @@ public interface NuProcess
     */
    void setProcessHandler(NuProcessHandler processHandler);
    
-   public int getPID();
+   int getPID();
 }

--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -164,4 +164,6 @@ public interface NuProcess
     * @param processHandler the new {@link NuProcessHandler}
     */
    void setProcessHandler(NuProcessHandler processHandler);
+   
+   public int getPID();
 }

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -364,6 +364,10 @@ public abstract class BasePosixProcess implements NuProcess
    {
       return pid;
    }
+   public int getPID()
+   {
+      return pid;
+   }
 
    public AtomicInteger getStdin()
    {

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
@@ -17,7 +17,6 @@
 package com.zaxxer.nuprocess.windows;
 
 import java.nio.ByteBuffer;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,7 +28,6 @@ import com.sun.jna.WString;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.W32APIOptions;
-
 import com.zaxxer.nuprocess.windows.NuWinNT.DWORD;
 import com.zaxxer.nuprocess.windows.NuWinNT.HANDLE;
 import com.zaxxer.nuprocess.windows.NuWinNT.SECURITY_ATTRIBUTES;
@@ -45,6 +43,8 @@ public class NuKernel32
       Native.register(NuKernel32.class, nativeLibrary);
    }
 
+   public static native int GetProcessId(HANDLE hObject);
+   
    public static native boolean CloseHandle(HANDLE hObject);
 
    public static native HANDLE CreateIoCompletionPort(HANDLE fileHandle, HANDLE existingCompletionPort, ULONG_PTR completionKey, int numberOfThreads);

--- a/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
@@ -167,7 +167,7 @@ public final class ProcessCompletions implements Runnable
       shutdown = true;
       Collection<WindowsProcess> processes = completionKeyToProcessMap.values();
       for (WindowsProcess process : processes) {
-         NuKernel32.TerminateProcess(process.getPid(), Integer.MAX_VALUE - 1);
+         NuKernel32.TerminateProcess(process.getPidHandle(), Integer.MAX_VALUE - 1);
          process.onExit(Integer.MAX_VALUE - 1);
       }
    }
@@ -305,7 +305,7 @@ public final class ProcessCompletions implements Runnable
       Iterator<WindowsProcess> iterator = deadPool.iterator();
       while (iterator.hasNext()) {
          WindowsProcess process = iterator.next();
-         if (NuKernel32.GetExitCodeProcess(process.getPid(), exitCode) && exitCode.getValue() != NuWinNT.STILL_ACTIVE) {
+         if (NuKernel32.GetExitCodeProcess(process.getPidHandle(), exitCode) && exitCode.getValue() != NuWinNT.STILL_ACTIVE) {
             iterator.remove();
             process.onExit(exitCode.getValue());
          }
@@ -319,7 +319,7 @@ public final class ProcessCompletions implements Runnable
       completionKeyToProcessMap.remove(process.getStderrPipe().ioCompletionKey);
 
       IntByReference exitCode = new IntByReference();
-      if (NuKernel32.GetExitCodeProcess(process.getPid(), exitCode) && exitCode.getValue() != NuWinNT.STILL_ACTIVE) {
+      if (NuKernel32.GetExitCodeProcess(process.getPidHandle(), exitCode) && exitCode.getValue() != NuWinNT.STILL_ACTIVE) {
          process.onExit(exitCode.getValue());
       }
       else {

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -219,7 +219,7 @@ public final class WindowsProcess implements NuProcess
    	   //PointerByReference pointer = new PointerByReference();
 	   //return NuKernel32.User32DLL.GetWindowThreadProcessId(null, null);
 
-       return NuKernel32.GetProcessId(this.getPid());
+       return NuKernel32.GetProcessId(this.getPidHandle());
    }
 
    /** {@inheritDoc} */
@@ -290,7 +290,7 @@ public final class WindowsProcess implements NuProcess
       return this;
    }
 
-   HANDLE getPid()
+   HANDLE getPidHandle()
    {
       return processInfo.hProcess;
    }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -214,6 +214,13 @@ public final class WindowsProcess implements NuProcess
    {
       NuKernel32.TerminateProcess(processInfo.hProcess, Integer.MAX_VALUE);
    }
+   
+   public int getPID(){
+   	   //PointerByReference pointer = new PointerByReference();
+	   //return NuKernel32.User32DLL.GetWindowThreadProcessId(null, null);
+
+       return NuKernel32.GetProcessId(this.getPid());
+   }
 
    /** {@inheritDoc} */
    @Override


### PR DESCRIPTION
Added the getPID() method to NuProcess interface.

Implemented it in WindowsProcess and BasePosixProcess.

getPID() returns an integer representing the actual OS process id.  