### PR TITLE
Optimize epoll_wait loop to avoid memory churn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /target
+/.idea
 .settings/org.eclipse.core.resources.prefs
 .settings/org.eclipse.jdt.core.prefs
 .settings/org.eclipse.m2e.core.prefs
+*.iml
+*.ipr
 org.eclipse.pde.core.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/benchmark/target
 /target
 /.idea
 .settings/org.eclipse.core.resources.prefs

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.zaxxer</groupId>
+    <artifactId>nuprocess-benchmark</artifactId>
+    <version>1.1.3-SNAPSHOT</version>
+
+    <name>NuProcess Benchmarks</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <jmh.version>1.19</jmh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>nuprocess</artifactId>
+            <version>1.1.3-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <annotationProcessors>
+                        <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+                    </annotationProcessors>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>${jmh.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/benchmark/src/main/java/com/zaxxer/nuprocess/benchmark/NuProcessBenchmark.java
+++ b/benchmark/src/main/java/com/zaxxer/nuprocess/benchmark/NuProcessBenchmark.java
@@ -1,0 +1,98 @@
+package com.zaxxer.nuprocess.benchmark;
+
+import com.zaxxer.nuprocess.NuAbstractProcessHandler;
+import com.zaxxer.nuprocess.NuProcess;
+import com.zaxxer.nuprocess.NuProcessBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.profile.HotspotThreadProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.CRC32;
+
+/**
+ * A simple performance benchmark which uses {@code cat} to write a file to {@code stdout}.
+ * <p>
+ * This benchmark requires a test file to use. One method to generate a test file is:
+ * <code><pre>
+ * head -c 250M /dev/urandom >/tmp/random.dat
+ * </pre></code>
+ * <p>
+ * The CRC32 for the file is also required to allow the benchmark to apply a spot check on the contents, after
+ * they've been pumped through {@code cat}, to verify that the contents were not corrupted during processing. A
+ * CRC32 checksum is used in preference to algorithms like SHA-256 because the speed of the hashing algorithm is
+ * not the focus of this benchmark.
+ * <p>
+ * After generating a test file, you can compute the CRC32 to update the benchmark by either running it once and
+ * checking the value in the error message, or running:
+ * <code><pre>
+ * crc32 /tmp/random.dat
+ * </pre></code>
+ * That will display the CRC32 checksum in hex, which can then be converted to decimal to match {@code CRC32}'s
+ * {@code getValue()}. (The calculator on most operating systems can convert hex to decimal.)
+ */
+public class NuProcessBenchmark {
+
+    private static final long TEST_CRC32 = 3407529827L;
+    private static final String TEST_FILE = "/tmp/random.dat";
+
+    public static void main(String[] args) throws Exception {
+        //System.setProperty("com.zaxxer.nuprocess.threads", "cores"); // set when running with forks(0) below
+
+        Options options = new OptionsBuilder()
+                .addProfiler(GCProfiler.class)
+                .addProfiler(HotspotThreadProfiler.class)
+                //.forks(0) // set when running with JProfiler to simplify profiling
+                .forks(2)
+                //.jvmArgsAppend("-Dcom.zaxxer.nuprocess.threads=cores") // to adjust the pump thread count
+                .include(NuProcessBenchmark.class.getSimpleName())
+                .measurementIterations(50)
+                .threads(10)
+                .timeUnit(TimeUnit.SECONDS)
+                .warmupIterations(1)
+                .build();
+
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    public void cat() throws Exception {
+        NuProcessBuilder builder = new NuProcessBuilder("cat", TEST_FILE);
+        builder.setProcessListener(new NuAbstractProcessHandler() {
+
+            private final CRC32 crc32 = new CRC32();
+
+            @Override
+            public void onExit(int statusCode) {
+                long crc = crc32.getValue();
+                if (crc != TEST_CRC32) {
+                    System.err.println("Incorrect CRC32 checksum (" + crc + "); file corruption?");
+                }
+            }
+
+            @Override
+            public void onStdout(ByteBuffer buffer, boolean closed) {
+                // the contents of the file are run through CRC32 just to "do" something with them
+                // note that update(ByteBuffer) requires Java 8. it's been selected because it doesn't
+                // inflate the measured allocation rate by allocating buffers internally
+                crc32.update(buffer);
+            }
+        });
+
+        NuProcess process = builder.start();
+
+        int exitCode = process.waitFor(5L, TimeUnit.MINUTES);
+        if (exitCode == Integer.MIN_VALUE) {
+            process.destroy(false);
+
+            throw new AssertionError(process + " took longer than 5 minutes to complete");
+        }
+        if (exitCode != 0) {
+            throw new AssertionError(process + " failed (Exit code: " + exitCode + ")");
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.1.0</version>
+            <version>4.5.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -43,7 +44,7 @@
             <name>Rich DiCroce</name>
         </developer>
         <developer>
-        	<name>Chris Cladden</name>
+            <name>Chris Cladden</name>
         </developer>
     </developers>
 

--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -105,6 +105,10 @@ public interface NuProcess
     * <p>
     * Otherwise, STDIN will be closed only after all pending writes
     * have completed.
+    *
+    * @param force if <code>true</code> is passed, STDIN will be immediately closed
+    *              even if there are pending writes; otherwise, it will be closed
+    *              after all pending writes are completed
     */
    void closeStdin(boolean force);
 

--- a/src/main/java/com/zaxxer/nuprocess/linux/LibEpoll.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LibEpoll.java
@@ -17,7 +17,7 @@
 package com.zaxxer.nuprocess.linux;
 
 import com.sun.jna.Native;
-import com.sun.jna.NativeLibrary;
+import com.sun.jna.Platform;
 
 /**
  * @author Brett Wooldridge
@@ -25,7 +25,7 @@ import com.sun.jna.NativeLibrary;
 public class LibEpoll
 {
    static {
-      Native.register(NativeLibrary.getProcess());
+      Native.register(Platform.C_LIBRARY_NAME);
    }
 
    public static native int sigignore(int signal);
@@ -34,15 +34,16 @@ public class LibEpoll
 
    public static native int epoll_ctl(int epfd, int op, int fd, EpollEvent event);
 
-   // technically, events should be an array, but we only ever call with maxevents = 1
+   // when passing "maxevents" >1, the first element in an EpollEvent[] of matching length should be
+   // passed as "events". create the array with new EpollEvent().toArray (and cast the result)
    public static native int epoll_wait(int epfd, EpollEvent events, int maxevents, int timeout);
 
    public static final int SIGPIPE = 13;
 
    /* from /usr/include/sys/epoll.h */
-   public static final int EPOLL_CTL_ADD = 1; /* Add a file decriptor to the interface.  */
-   public static final int EPOLL_CTL_DEL = 2; /* Change file decriptor epoll_event structure.  */
-   public static final int EPOLL_CTL_MOD = 3; /* Remove a file decriptor from the interface.  */
+   public static final int EPOLL_CTL_ADD = 1; /* Add a file descriptor to the interface.  */
+   public static final int EPOLL_CTL_DEL = 2; /* Remove a file descriptor from the interface.  */
+   public static final int EPOLL_CTL_MOD = 3; /* Change file descriptor epoll_event structure.  */
 
    public static final int EPOLLIN = 0x001;
    public static final int EPOLLOUT = 0x004;
@@ -50,5 +51,4 @@ public class LibEpoll
    public static final int EPOLLHUP = 0x010;
    public static final int EPOLLRDHUP = 0x2000;
    public static final int EPOLLONESHOT = (1 << 30);
-   public static final int EPOLLET = (1 << 31);
 }

--- a/src/test/java/com/zaxxer/nuprocess/linux/EpollEventTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/linux/EpollEventTest.java
@@ -1,0 +1,15 @@
+package com.zaxxer.nuprocess.linux;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EpollEventTest
+{
+   // ensure EpollEvent is 12 bytes, to match its size in C
+   @Test
+   public void testSize()
+   {
+      EpollEvent event = new EpollEvent();
+      Assert.assertEquals(12, event.size());
+   }
+}


### PR DESCRIPTION
- Disabled `autoRead` and/or `autoWrite` on `EpollEvent` structs depending on how they're used, in `ProcessEpoll`
  - `EpollEvent`s in the `eventPool` have `autoRead` disabled because they are used a write-only context (Calling `epoll_ctl`)
  - The `triggeredEvent` `EpollEvent` has both `autoRead`/`autoWrite` disabled
    - When `epoll_wait` returns 1, `read()` is called explicitly, but if it returns 0 native memory is not read
    - Prior to calling `epoll_ctl` to register for further stdin events, `write()` is called explicitly
- Fixed memory alignment on `EpollEvent` and added a unit test to verify the size of the struct is 12 bytes
- Removed `EpollEvent.EpollData.ptr` because, even though it's never used, JNA still allocates it
- Replaced `Integer`s with `int`s using `Integer.MIN_VALUE` as a marker, when acquiring descriptors, to avoid allocating 3 per `process()` loop
  - If the process soft-exits, `Integer`s will still be created then

Extra bits:
- Added IntelliJ IDEA files to `.gitignore`
- Updated JNA to 4.5.1