### PR TITLE
Add constructor with com.sun.jna.Pointer to LibKevent.Kevent

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/osx/LibKevent.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/LibKevent.java
@@ -60,6 +60,14 @@ public class LibKevent
       public NativeLong data;
       public Pointer udata;
 
+      public Kevent() {
+          super();
+      }
+
+      public Kevent(Pointer p) {
+          super(p);
+      }
+
       @SuppressWarnings("rawtypes")
       @Override
       protected List getFieldOrder()


### PR DESCRIPTION
**What this PR does?**

 - adds a constructor with ```com.sun.jna.Pointer``` to ```LibKevent.Kevent``` which in it's turn calls constructor from super

**What this PR solves?**
 - an issue with extra and unnecessary lookup for a constructor and extra exception handling.

**Problem description:**

When in ```com.zaxxer.nuprocess.osx.ProcessKqueue#registerProcess``` an array of Kevent is created by using method ```com.sun.jna.Structure#toArray(int)```,

```
Kevent[] events = (Kevent[]) new Kevent().toArray(4);
```

then eventually method ```com.sun.jna.Structure#newInstance(java.lang.Class<?>, com.sun.jna.Pointer)``` searches for constructor which accepts Pointer. And there is a try..catch with some additional logic which calls ```com.sun.jna.Structure#useMemory```.

Currently when creating thousands of processes, it ads extra unnecessary calls which seems not really optimal.
Since the ```LibKevent.Kevent``` is a subclass of ```com.sun.jna.Structure```, then it looks reasonable to implement it's constructor ```com.sun.jna.Structure#Structure(com.sun.jna.Pointer)```

Without this patch I see thousands of exceptions with following stack trace in ```jmc```

```
void jdk.jfr.internal.instrument.ThrowableTracer.traceThrowable(Throwable, String)
void java.lang.Throwable.<init>(String)
void java.lang.Exception.<init>(String)
void java.lang.ReflectiveOperationException.<init>(String)
void java.lang.NoSuchMethodException.<init>(String)
Constructor java.lang.Class.getConstructor0(Class[], int)
Constructor java.lang.Class.getConstructor(Class[])
Structure com.sun.jna.Structure.newInstance(Class, Pointer)
Structure[] com.sun.jna.Structure.toArray(Structure[])
Structure[] com.sun.jna.Structure.toArray(int)
void com.zaxxer.nuprocess.osx.ProcessKqueue.registerProcess(OsxProcess)
void com.zaxxer.nuprocess.osx.ProcessKqueue.registerProcess(BasePosixProcess)
void com.zaxxer.nuprocess.internal.BasePosixProcess.registerProcess()
NuProcess com.zaxxer.nuprocess.internal.BasePosixProcess.start(List, String[], Path)
NuProcess com.zaxxer.nuprocess.osx.OsxProcessFactory.createProcess(List, String[], NuProcessHandler, Path)
NuProcess com.zaxxer.nuprocess.NuProcessBuilder.start()
NuProcess com.badoo.automation.deviceserver.command.ShellCommand.startProcessInternal(List, Map, IShellCommandListener)
```