### PR TITLE
Adds ability to run processes synchronously (#95).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zaxxer</groupId>
     <artifactId>nuprocess</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>NuProcess</name>

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -253,16 +253,41 @@ public class NuProcessBuilder
     */
    public NuProcess start()
    {
+      ensureListener();
+      String[] env = prepareEnvironment();
+
+      return factory.createProcess(command, env, processListener, cwd);
+   }
+
+   /**
+    * Spawn the child process with the configured commands, environment, and {@link NuProcessHandler}
+    * and wait for it to complete running.
+    *
+    * @since 1.3
+    */
+   public void run()
+   {
+      ensureListener();
+      String[] env = prepareEnvironment();
+
+      factory.runProcess(command, env, processListener, cwd);
+   }
+
+   private void ensureListener()
+   {
       if (processListener == null) {
          throw new IllegalArgumentException("NuProcessHandler not specified");
       }
+   }
 
+   private String[] prepareEnvironment()
+   {
       String[] env = new String[environment.size()];
       int i = 0;
       for (Entry<String, String> entrySet : environment.entrySet()) {
          env[i++] = entrySet.getKey() + "=" + entrySet.getValue();
       }
 
-      return factory.createProcess(command, env, processListener, cwd);
+      return env;
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessFactory.java
@@ -28,4 +28,13 @@ import java.util.List;
 public interface NuProcessFactory
 {
    NuProcess createProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd);
+
+   /**
+    * Runs the process synchronously.
+    *
+    * Pumping is done on the calling thread, and this method will not return until the process has exited.
+    *
+    * @since 1.3
+    */
+   void runProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd);
 }

--- a/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
@@ -71,7 +71,10 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
    public void run()
    {
       try {
-         startBarrier.await();
+         // If the process is running synchronously, startBarrier will be null
+         if (startBarrier != null) {
+            startBarrier.await();
+         }
 
          int idleCount = 0;
          while (!isRunning.compareAndSet(idleCount > lingerIterations && pidToProcessMap.isEmpty(), false)) {

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -130,6 +130,15 @@ public abstract class BasePosixProcess implements NuProcess
    public abstract NuProcess start(List<String> command, String[] environment, Path cwd);
 
    /**
+    * Runs the process synchronously.
+    *
+    * Pumping is done on the calling thread, and this method will not return until the process has exited.
+    *
+    * @since 1.3
+    */
+   public abstract void run(List<String> command, String[] environment, Path cwd);
+
+   /**
     * Check the launched process and return {@code true} if launch was successful,
     * or {@code false} if there was an error in launch.
     *

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinProcessFactory.java
@@ -41,4 +41,12 @@ public class LinProcessFactory implements NuProcessFactory
       }
       return process;
    }
+
+   /** {@inheritDoc} */
+   @Override
+   public void runProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
+   {
+      LinuxProcess process = new LinuxProcess(processListener);
+      process.run(commands, env, cwd);
+   }
 }

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -21,6 +21,7 @@ import com.sun.jna.ptr.IntByReference;
 import com.zaxxer.nuprocess.NuProcess;
 import com.zaxxer.nuprocess.NuProcessHandler;
 import com.zaxxer.nuprocess.internal.BasePosixProcess;
+import com.zaxxer.nuprocess.internal.IEventProcessor;
 import com.zaxxer.nuprocess.internal.LibC;
 
 import java.nio.file.Path;
@@ -65,6 +66,65 @@ public class LinuxProcess extends BasePosixProcess
    public NuProcess start(List<String> command, String[] environment, Path cwd) {
       callPreStart();
 
+      try {
+         prepareProcess(command, environment, cwd);
+
+         if (pid == -1) {
+            return null;
+         }
+
+         closePipes();
+
+         initializeBuffers();
+
+         afterStart();
+
+         registerProcess();
+
+         callStart();
+      }
+      catch (Exception e) {
+         // TODO remove from event processor pid map?
+         LOGGER.log(Level.WARNING, "Failed to start process", e);
+         onExit(Integer.MIN_VALUE);
+         return null;
+      }
+
+      return this;
+   }
+
+   @Override
+   public void run(List<String> command, String[] environment, Path cwd)
+   {
+      callPreStart();
+
+      try {
+         prepareProcess(command, environment, cwd);
+
+         if (pid == -1) {
+            return;
+         }
+
+         closePipes();
+
+         initializeBuffers();
+
+         afterStart();
+
+         myProcessor = (IEventProcessor) new ProcessEpoll(this);
+
+         callStart();
+
+         myProcessor.run();
+      }
+      catch (Exception e) {
+         LOGGER.log(Level.WARNING, "Failed to start process", e);
+         onExit(Integer.MIN_VALUE);
+      }
+   }
+
+   private void prepareProcess(List<String> command, String[] environment, Path cwd)
+   {
       String[] cmdarray = command.toArray(new String[0]);
 
       // See https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/java/lang/ProcessImpl.java#L71-L83
@@ -85,65 +145,46 @@ public class LinuxProcess extends BasePosixProcess
       // See https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/java/lang/ProcessImpl.java#L86
       byte[] envBlock = toEnvironmentBlock(environment);
 
-      try {
-         // See https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/java/lang/ProcessImpl.java#L96
-         createPipes();
-         int[] child_fds = {stdinWidow, stdoutWidow, stderrWidow};
+      // See https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/java/lang/ProcessImpl.java#L96
+      createPipes();
+      int[] child_fds = {stdinWidow, stdoutWidow, stderrWidow};
 
-         if (JVM_MAJOR_VERSION >= 10 || isAzul) {
-            pid = com.zaxxer.nuprocess.internal.LibJava10.Java_java_lang_ProcessImpl_forkAndExec(
-                  JNIEnv.CURRENT,
-                  this,
-                  LaunchMechanism.VFORK.ordinal() + 1,
-                  toCString(System.getProperty("java.home") + "/lib/jspawnhelper"), // used on Linux
-                  toCString(cmdarray[0]),
-                  argBlock, args.length,
-                  envBlock, environment.length,
-                  (cwd != null ? toCString(cwd.toString()) : null),
-                  child_fds,
-                  (byte) 0 /*redirectErrorStream*/);
-         }
-         else {
-            // See https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/java/lang/UNIXProcess.java#L247
-            // Native source code: https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/native/java/lang/UNIXProcess_md.c#L566
-            pid = com.zaxxer.nuprocess.internal.LibJava8.Java_java_lang_UNIXProcess_forkAndExec(
-                  JNIEnv.CURRENT,
-                  this,
-                  LaunchMechanism.VFORK.ordinal() + 1,
-                  toCString(System.getProperty("java.home") + "/lib/jspawnhelper"), // used on Linux
-                  toCString(cmdarray[0]),
-                  argBlock, args.length,
-                  envBlock, environment.length,
-                  (cwd != null ? toCString(cwd.toString()) : null),
-                  child_fds,
-                  (byte) 0 /*redirectErrorStream*/);
-         }
-
-         if (pid == -1) {
-            return null;
-         }
-
-         // Close the child end of the pipes in our process
-         LibC.close(stdinWidow);
-         LibC.close(stdoutWidow);
-         LibC.close(stderrWidow);
-
-         initializeBuffers();
-
-         afterStart();
-
-         registerProcess();
-
-         callStart();
+      if (JVM_MAJOR_VERSION >= 10 || isAzul) {
+         pid = com.zaxxer.nuprocess.internal.LibJava10.Java_java_lang_ProcessImpl_forkAndExec(
+               JNIEnv.CURRENT,
+               this,
+               LaunchMechanism.VFORK.ordinal() + 1,
+               toCString(System.getProperty("java.home") + "/lib/jspawnhelper"), // used on Linux
+               toCString(cmdarray[0]),
+               argBlock, args.length,
+               envBlock, environment.length,
+               (cwd != null ? toCString(cwd.toString()) : null),
+               child_fds,
+               (byte) 0 /*redirectErrorStream*/);
       }
-      catch (Exception e) {
-         // TODO remove from event processor pid map?
-         LOGGER.log(Level.WARNING, "Failed to start process", e);
-         onExit(Integer.MIN_VALUE);
-         return null;
+      else {
+         // See https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/classes/java/lang/UNIXProcess.java#L247
+         // Native source code: https://github.com/JetBrains/jdk8u_jdk/blob/master/src/solaris/native/java/lang/UNIXProcess_md.c#L566
+         pid = com.zaxxer.nuprocess.internal.LibJava8.Java_java_lang_UNIXProcess_forkAndExec(
+               JNIEnv.CURRENT,
+               this,
+               LaunchMechanism.VFORK.ordinal() + 1,
+               toCString(System.getProperty("java.home") + "/lib/jspawnhelper"), // used on Linux
+               toCString(cmdarray[0]),
+               argBlock, args.length,
+               envBlock, environment.length,
+               (cwd != null ? toCString(cwd.toString()) : null),
+               child_fds,
+               (byte) 0 /*redirectErrorStream*/);
       }
+   }
 
-      return this;
+   private void closePipes()
+   {
+      // Close the child end of the pipes in our process
+      LibC.close(stdinWidow);
+      LibC.close(stdoutWidow);
+      LibC.close(stderrWidow);
    }
 
    @Override

--- a/src/main/java/com/zaxxer/nuprocess/linux/ProcessEpoll.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/ProcessEpoll.java
@@ -183,7 +183,8 @@ class ProcessEpoll extends BaseEventProcessor<LinuxProcess>
    }
 
    @Override
-   public void run() {
+   public void run()
+   {
       super.run();
 
       if (process != null) {
@@ -287,6 +288,17 @@ class ProcessEpoll extends BaseEventProcessor<LinuxProcess>
          }
          checkDeadPool();
       }
+   }
+
+   /**
+    * Closes the {@code eventpoll} file descriptor.
+    *
+    * @since 1.3
+    */
+   @Override
+   protected void close()
+   {
+      LibC.close(epoll);
    }
 
    // ************************************************************************

--- a/src/main/java/com/zaxxer/nuprocess/osx/OsxProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/OsxProcessFactory.java
@@ -34,4 +34,12 @@ public class OsxProcessFactory implements NuProcessFactory
       process.start(commands, env, cwd);
       return process;
    }
+
+   /** {@inheritDoc} */
+   @Override
+   public void runProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
+   {
+      OsxProcess process = new OsxProcess(processListener);
+      process.run(commands, env, cwd);
+   }
 }

--- a/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
@@ -240,6 +240,17 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
       return true;
    }
 
+   /**
+    * Closes the {@code kqueue} file descriptor.
+    *
+    * @since 1.3
+    */
+   @Override
+   protected void close()
+   {
+      LibC.close(kqueue);
+   }
+
    private void processEvent(Kevent kevent)
    {
       int ident = kevent.ident.intValue();

--- a/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
@@ -60,7 +60,21 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
 
    ProcessKqueue()
    {
-      super(LINGER_ITERATIONS);
+      this(LINGER_ITERATIONS);
+   }
+
+   ProcessKqueue(OsxProcess process)
+   {
+      this(-1);
+
+      registerProcess(process);
+      checkAndSetRunning();
+   }
+
+   private ProcessKqueue(int lingerIterations)
+   {
+      super(lingerIterations);
+
       kqueue = LibKevent.kqueue();
       if (kqueue < 0) {
          throw new RuntimeException("Unable to create kqueue");

--- a/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
@@ -125,6 +125,13 @@ public final class ProcessCompletions implements Runnable
          e.printStackTrace();
          isRunning.set(false);
       }
+      finally {
+         if (startBarrier == null) {
+            // If the process is running synchronously, when the run loop ends the I/O completion
+            // port will never be reused so it needs to be closed to avoid leaking handles
+            NuKernel32.CloseHandle(ioCompletionPort);
+         }
+      }
    }
 
    public boolean process()

--- a/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
@@ -44,6 +44,8 @@ public final class ProcessCompletions implements Runnable
    private static final int STDOUT = 0;
    private static final int STDERR = 1;
 
+   private final int lingerIterations;
+
    private HANDLE ioCompletionPort;
 
    private List<WindowsProcess> deadPool;
@@ -69,6 +71,25 @@ public final class ProcessCompletions implements Runnable
 
    ProcessCompletions()
    {
+      this(LINGER_ITERATIONS);
+   }
+
+   ProcessCompletions(WindowsProcess process)
+   {
+      this(-1);
+
+      if (process == null) {
+         throw new IllegalArgumentException("process");
+      }
+
+      registerProcess(process);
+      checkAndSetRunning();
+   }
+
+   private ProcessCompletions(int lingerIterations)
+   {
+      this.lingerIterations = lingerIterations;
+
       completionKeyToProcessMap = new HashMap<>();
       wantsWrite = new ArrayBlockingQueue<>(512);
       pendingPool = new LinkedBlockingQueue<>();
@@ -89,10 +110,13 @@ public final class ProcessCompletions implements Runnable
    public void run()
    {
       try {
-         startBarrier.await();
+         // If the process is running synchronously, startBarrier will be null
+         if (startBarrier != null) {
+            startBarrier.await();
+         }
 
          int idleCount = 0;
-         while (!isRunning.compareAndSet(idleCount > LINGER_ITERATIONS && deadPool.isEmpty() && completionKeyToProcessMap.isEmpty(), false)) {
+         while (!isRunning.compareAndSet(idleCount > lingerIterations && completionKeyToProcessMap.isEmpty() && deadPool.isEmpty() && pendingPool.isEmpty(), false)) {
             idleCount = (!shutdown && process()) ? 0 : (idleCount + 1);
          }
       }

--- a/src/main/java/com/zaxxer/nuprocess/windows/WinProcessFactory.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WinProcessFactory.java
@@ -42,4 +42,12 @@ public class WinProcessFactory implements NuProcessFactory
       process.start(commands, env, cwd);
       return process;
    }
+
+   /** {@inheritDoc} */
+   @Override
+   public void runProcess(List<String> commands, String[] env, NuProcessHandler processListener, Path cwd)
+   {
+      WindowsProcess process = new WindowsProcess(processListener);
+      process.run(commands, env, cwd);
+   }
 }


### PR DESCRIPTION
As per discussed in #95, this one implements ability to run processes synchronously with pumping happening on the client thread.

To achieve that, it extends builder, factory and process classes with `run` method that starts the process and then creates new event processor per client to listen for events. Processor then executes event loop the same way as it does for asynchronous code path.

The change is tested with new `runProcessSynchronously` test in `CatTest`.

Additionally it bumps minor version, because we've added a new feature here.