### PR TITLE
[version detection] Handle detecting java version when non-numbers are present

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/Constants.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/Constants.java
@@ -13,12 +13,19 @@ public class Constants
       SOLARIS
    }
 
+   static int getJavaMajorVersion(String versionString) {
+       String[] parts = versionString.split("\\.");
+       // Make sure we handle versions like '11-ea' which ships with centos7
+       int major = Integer.parseInt(parts[0].split("\\D")[0]);
+       if (major == 1) {
+         major = Integer.parseInt(parts[1].split("\\D")[0]);
+       }
+       return major;
+   }
+
    static {
-      String[] parts = System.getProperty("java.version").split("\\.");
-      int major = Integer.valueOf(parts[0]);
-      if (major == 1)
-        major = Integer.valueOf(parts[1]);
-      JVM_MAJOR_VERSION = major;
+
+      JVM_MAJOR_VERSION = getJavaMajorVersion(System.getProperty("java.version"));
 
       final String osname = System.getProperty("os.name").toLowerCase();
       if (osname.contains("mac") || osname.contains("freebsd"))

--- a/src/test/java/com/zaxxer/nuprocess/internal/ConstantsTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/internal/ConstantsTest.java
@@ -1,0 +1,19 @@
+package com.zaxxer.nuprocess.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ConstantsTest {
+  @Test
+  public void parsesVersionStrings() {
+    Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8.0_foo"));
+    Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8_foo"));
+    Assert.assertEquals(11, Constants.getJavaMajorVersion("11_foo"));
+    Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8.0-foo"));
+    Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8-foo"));
+    Assert.assertEquals(11, Constants.getJavaMajorVersion("11-foo"));
+    Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8.0"));
+    Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8"));
+    Assert.assertEquals(11, Constants.getJavaMajorVersion("11"));
+  }
+}


### PR DESCRIPTION
Centos 7 can have a java 11 package that returns '11-ea' from
'java.version'. This causes an exception to be thrown in class
initialization. Make this slightly more robust, add a few tests as well.