### PR TITLE
Don't special case Azul JVMs.

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -35,11 +35,7 @@ import static com.zaxxer.nuprocess.internal.Constants.JVM_MAJOR_VERSION;
  */
 public class LinuxProcess extends BasePosixProcess
 {
-   private static final boolean isAzul;
-
    static {
-      isAzul = System.getProperty("java.vm.vendor", "").contains("Azul");
-
       LibEpoll.sigignore(LibEpoll.SIGPIPE);
 
       // TODO: install signal handler for SIGCHLD, and call onExit() when received, call the default (JVM) hook if the PID is not ours
@@ -90,7 +86,7 @@ public class LinuxProcess extends BasePosixProcess
          createPipes();
          int[] child_fds = {stdinWidow, stdoutWidow, stderrWidow};
 
-         if (JVM_MAJOR_VERSION >= 10 || isAzul) {
+         if (JVM_MAJOR_VERSION >= 10) {
             pid = com.zaxxer.nuprocess.internal.LibJava10.Java_java_lang_ProcessImpl_forkAndExec(
                   JNIEnv.CURRENT,
                   this,


### PR DESCRIPTION
On #87 (May 2018), there was a report of a linkage issue when using Azul Zulu 10. As part of fixing that issue, a check was added to use a new code path when the JVM vendor included "Azul".

A month later, #91 (June 2018) was created showing a similar linkage error when using OpenJDK 10. For that issue, the Azul-specific change from #87 was generalized to apply to any Java 10+ JVM, but the Azul vendor check was not removed. As a result, Azul Zulu 8 (for example) attempts to use the Java 10 code path and fails.

- Removed the Azul vendor check. Now, regardless of JVM vendor:
  - Java 10+ JVMs use `Java_java_lang_ProcessImpl_forkAndExec`
  - Earlier JVMs use `Java_java_lang_UNIXProcess_forkAndExec`