### PR TITLE
Reduce pipe buffer size on Windows (fixes #117).

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
@@ -102,16 +102,10 @@ public class NuKernel32
          super();
       }
 
-      public OVERLAPPED(Pointer p)
-      {
-         super(p);
-      }
-
       @Override
-      @SuppressWarnings("rawtypes")
-      protected List getFieldOrder()
+      protected List<String> getFieldOrder()
       {
-         return Arrays.asList(new String[] { "Internal", "InternalHigh", "Offset", "OffsetHigh", "hEvent" });
+         return Arrays.asList("Internal", "InternalHigh", "Offset", "OffsetHigh", "hEvent");
       }
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuWinNT.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuWinNT.java
@@ -58,10 +58,12 @@ public interface NuWinNT
 
    int STARTF_USESTDHANDLES = 0x100;
 
-   HANDLE INVALID_HANDLE_VALUE = new HANDLE(Pointer.createConstant(Native.POINTER_SIZE == 8 ? -1 : 0xFFFFFFFFL));
+   HANDLE INVALID_HANDLE_VALUE = new HANDLE(HANDLE.INVALID);
 
    class HANDLE extends PointerType
    {
+      static final Pointer INVALID = Pointer.createConstant(Native.POINTER_SIZE == 8 ? -1 : 0xFFFFFFFFL);
+
       public HANDLE()
       {
       }
@@ -74,15 +76,15 @@ public interface NuWinNT
       @Override
       public Object fromNative(Object nativeValue, FromNativeContext context)
       {
-         Object o = super.fromNative(nativeValue, context);
-         if (INVALID_HANDLE_VALUE.equals(o)) {
+         Pointer ptr = (Pointer) nativeValue;
+         if (INVALID.equals(ptr)) {
             return INVALID_HANDLE_VALUE;
          }
-         return o;
+         return new HANDLE(ptr);
       }
    }
 
-   static class WORD extends IntegerType
+   class WORD extends IntegerType
    {
       public static final int SIZE = 2;
 
@@ -97,7 +99,7 @@ public interface NuWinNT
       }
    }
 
-   static class DWORD extends IntegerType
+   class DWORD extends IntegerType
    {
       public static final int SIZE = 4;
 
@@ -112,7 +114,7 @@ public interface NuWinNT
       }
    }
 
-   static class ULONG_PTR extends IntegerType
+   class ULONG_PTR extends IntegerType
    {
       public ULONG_PTR()
       {
@@ -123,14 +125,9 @@ public interface NuWinNT
       {
          super(Native.POINTER_SIZE, value, true);
       }
-
-      public Pointer toPointer()
-      {
-         return Pointer.createConstant(longValue());
-      }
    }
 
-   static class ULONG_PTRByReference extends ByReference
+   class ULONG_PTRByReference extends ByReference
    {
       public ULONG_PTRByReference()
       {
@@ -166,10 +163,9 @@ public interface NuWinNT
       public boolean bInheritHandle;
 
       @Override
-      @SuppressWarnings("rawtypes")
-      protected List getFieldOrder()
+      protected List<String> getFieldOrder()
       {
-         return Arrays.asList(new String[] { "dwLength", "lpSecurityDescriptor", "bInheritHandle" });
+         return Arrays.asList("dwLength", "lpSecurityDescriptor", "bInheritHandle");
       }
    }
 
@@ -194,17 +190,17 @@ public interface NuWinNT
       public HANDLE hStdOutput;
       public HANDLE hStdError;
 
-      @Override
-      @SuppressWarnings("rawtypes")
-      protected List getFieldOrder()
-      {
-         return Arrays.asList(new String[] { "cb", "lpReserved", "lpDesktop", "lpTitle", "dwX", "dwY", "dwXSize", "dwYSize", "dwXCountChars", "dwYCountChars",
-               "dwFillAttribute", "dwFlags", "wShowWindow", "cbReserved2", "lpReserved2", "hStdInput", "hStdOutput", "hStdError" });
-      }
-
       public STARTUPINFO()
       {
          cb = new DWORD(size());
+      }
+
+      @Override
+      protected List<String> getFieldOrder()
+      {
+         return Arrays.asList("cb", "lpReserved", "lpDesktop", "lpTitle", "dwX", "dwY", "dwXSize", "dwYSize",
+               "dwXCountChars", "dwYCountChars", "dwFillAttribute", "dwFlags", "wShowWindow", "cbReserved2",
+               "lpReserved2", "hStdInput", "hStdOutput", "hStdError");
       }
    }
 
@@ -216,10 +212,9 @@ public interface NuWinNT
       public DWORD dwThreadId;
 
       @Override
-      @SuppressWarnings("rawtypes")
-      protected List getFieldOrder()
+      protected List<String> getFieldOrder()
       {
-         return Arrays.asList(new String[] { "hProcess", "hThread", "dwProcessId", "dwThreadId" });
+         return Arrays.asList("hProcess", "hThread", "dwProcessId", "dwThreadId");
       }
    }
 }

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuWinNT.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuWinNT.java
@@ -76,6 +76,10 @@ public interface NuWinNT
       @Override
       public Object fromNative(Object nativeValue, FromNativeContext context)
       {
+         if (nativeValue == null) {
+            return null;
+         }
+
          Pointer ptr = (Pointer) nativeValue;
          if (INVALID.equals(ptr)) {
             return INVALID_HANDLE_VALUE;


### PR DESCRIPTION
Using a large buffer size for the pipe connecting the child process can result in IOCP imposing (very short) delays before notifying the port when a read completes, waiting in case additional data arrives. For a small number of reads the short delays are no problem, but for processes that produce hundreds of megabytes of output (especially if they do so in small bursts, like `git http-backend` and `git upload-pack`) all those short delays accumulate into a massive performance hit, reducing throughput compared to `ProcessBuilder` by an order of magnitude (30MB/s+ down to 2MB/s).

Using a smaller pipe buffer does impose some constraint on how much data can be moved by a single `ReadFile` or `WriteFile` call but it also prevents delays (because there's no point in waiting for more input if the buffer is already full), resulting in overall improved--and, more importantly, more consistent--performance.

- Reduced `WindowsProcess.BUFFER_SIZE` from 64K to 4096+24, which matches the buffer size the JDK's `ProcessImpl` uses on Windows
- Replaced `System.err` with a `Logger` when writing errors
  - This matches how `LinuxProcess` and `OsxProcess` are written
- Optimized `HANDLE.fromNative` to check the pointer directly, to avoid creating `HANDLE` instances for invalid handles
  - This also avoids the base implementation's use of reflection to instantiate new `HANDLE` instances
- Updated `PipeBundle` to set auto-sync to false on `OVERLAPPED` instances so JNA won't waste time marshaling to/from native code around every call to `ReadFile` or `WriteFile`