### PR TITLE
Ensure LinuxProcess closes pipes if starting a process fails (fixes #119)

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/LibJava10.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibJava10.java
@@ -21,6 +21,7 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -71,5 +72,5 @@ public class LibJava10
            Object dir,
            Object fds,
            byte redirectErrorStream
-   );
+   ) throws IOException;
 }

--- a/src/main/java/com/zaxxer/nuprocess/internal/LibJava8.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibJava8.java
@@ -21,6 +21,7 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.NativeLibrary;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -70,5 +71,5 @@ public class LibJava8
            Object dir,
            Object fds,
            byte redirectErrorStream
-   );
+   ) throws IOException;
 }

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -23,6 +23,7 @@ import com.zaxxer.nuprocess.internal.BasePosixProcess;
 import com.zaxxer.nuprocess.internal.IEventProcessor;
 import com.zaxxer.nuprocess.internal.LibC;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Level;
@@ -111,7 +112,7 @@ public class LinuxProcess extends BasePosixProcess
       }
    }
 
-   private void prepareProcess(List<String> command, String[] environment, Path cwd)
+   private void prepareProcess(List<String> command, String[] environment, Path cwd) throws IOException
    {
       String[] cmdarray = command.toArray(new String[0]);
 

--- a/src/main/java/com/zaxxer/nuprocess/osx/OsxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/OsxProcess.java
@@ -61,11 +61,6 @@ class OsxProcess extends BasePosixProcess
 
       try {
          int rc = prepareProcess(environment, cwd, commands, posix_spawn_file_actions, posix_spawnattr);
-
-         if (!checkLaunch()) {
-            return null;
-         }
-
          checkReturnCode(rc, "Invocation of posix_spawn() failed");
 
          afterStart();
@@ -105,11 +100,6 @@ class OsxProcess extends BasePosixProcess
 
       try {
          int rc = prepareProcess(environment, cwd, commands, posix_spawn_file_actions, posix_spawnattr);
-
-         if (!checkLaunch()) {
-            return;
-         }
-
          checkReturnCode(rc, "Invocation of posix_spawn() failed");
 
          afterStart();


### PR DESCRIPTION
- Fixed the `forkAndExec` native signatures to include `throws IOException` to match `ProcessImpl`'s version
  - This makes it more obvious that the calls in `LinuxProcess.prepareProcess` can throw on errors
- Moved calls to `LinuxProcess.closePipes()` from `run()` and `start()` into `prepareProcess` in a `try`/`finally` block around calls to the JVM's `forkAndExec` function
  - This way, if `forkAndExec` throws (which it does, on failure, as the signature change highlights) the `*Widow` descriptors are all closed
  - The non-`*Widow` ends of the pipes are closed in `onExit`, so they are already handled after failures
- Removed `BasePosixProcess.checkLaunch`
  - `OsxProcess` was the only place calling it, but `OsxProcess` didn't override it (so the call did nothing)
  - `LinuxProcess` override it, but since it was switched to using the JVM's `forkAndExec` function it no longer _calls_ it, so the override was just dead code
- Simplified `BasePosixProcess.initFailureCleanup`
- Updated some `BasePosixProcess` error paths to log their exceptions