### PR TITLE
Handle EINTR during epoll_wait.

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.sun.jna.ptr.IntByReference;
 
@@ -33,6 +35,9 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
 
    protected static final int DEADPOOL_POLL_INTERVAL;
    protected static final int LINGER_ITERATIONS;
+
+   private static final Logger LOGGER = Logger.getLogger(BaseEventProcessor.class.getCanonicalName());
+
    private final int lingerIterations;
 
    protected Map<Integer, T> pidToProcessMap;
@@ -83,6 +88,8 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
       }
       catch (Exception e) {
          // TODO: how to handle this error?
+         LOGGER.log(Level.WARNING, "Aborting processing loop after unexpected exception (" +
+                 pidToProcessMap.size() + " processes running)", e);
          isRunning.set(false);
       }
       finally {

--- a/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
@@ -94,6 +94,7 @@ public class LibC
    public static final int O_NONBLOCK;
 
    // from /usr/include/asm-generic/errno-base.h
+   public static final int EINTR = 4;   /* Interrupted system call */
    public static final int ECHILD = 10; /* No child processes */
 
    // from /usr/include/sys/wait.h

--- a/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/ProcessCompletions.java
@@ -27,6 +27,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
@@ -41,6 +43,7 @@ public final class ProcessCompletions implements Runnable
 {
    private static final int DEADPOOL_POLL_INTERVAL;
    private static final int LINGER_ITERATIONS;
+   private static final Logger LOGGER = Logger.getLogger(ProcessCompletions.class.getCanonicalName());
    private static final int STDOUT = 0;
    private static final int STDERR = 1;
 
@@ -122,7 +125,8 @@ public final class ProcessCompletions implements Runnable
       }
       catch (Exception e) {
          // TODO: how to handle this error?
-         e.printStackTrace();
+         LOGGER.log(Level.WARNING, "Aborting processing loop after unexpected exception (" +
+                 completionKeyToProcessMap.size() + " processes running)", e);
          isRunning.set(false);
       }
       finally {


### PR DESCRIPTION
`epoll_wait` is not restarted after it's interrupted by a signal handler, even if the handler used `SA_RESTART`. Instead, the calling code needs to handle the `EINTR` and restart the call itself.

- Added logging in `BaseEventProcessor` and `ProcessCompletions` when the `process()` loop is aborted due to an exception
- Added `EINTR` to `LibC`
- Updated `ProcessEpoll` to detect `EINTR` after `epoll_wait` fails and return `true` to retry the call

Fixes #124 