### PR TITLE
Handle ESRCH from kill. (fixes #130)

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
@@ -94,6 +94,7 @@ public class LibC
    public static final int O_NONBLOCK;
 
    // from /usr/include/asm-generic/errno-base.h
+   public static final int ESRCH = 3;   /* No such process */
    public static final int ECHILD = 10; /* No child processes */
 
    // from /usr/include/sys/wait.h


### PR DESCRIPTION
When `kill` returns non-zero, check `errno` and, if it's `ESRCH`, log a debug message indicating the process has already exited instead of throwing.

- Added `LibC.ESRCH`
- Updated `BasePosixProcess.destroy` to check `Native.getLastError()` after `LibC.kill` returns non-zero and log for `ESRCH` instead of throwing