### PR TITLE
Use Job objects in lieu of a shutdown hook on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ This property controls how long the processing thread(s) remains after the last 
 order to avoid the overhead of starting up another processing thread, if processes are frequently run it may be desirable
 for the processing thread to remain (linger) for some amount of time (default 2500ms).
 
+##### ``com.zaxxer.nuprocess.enableShutdownHook``
+On Windows, this enables creating processes with job objects, which ensures they die when the parent process dies, in all
+circumstances. On Linux and macOS, this creates a Java shutdown hook that quits created, running processes. This has the
+same limitations as shutdown hooks, which may not run in certain circumstances like termination. The default value is "true".
+
 #### Related Projects
 Charles Duffy has developed a Clojure wrapper library [here](https://github.com/threatgrid/asynp).
 Julien Viet has developed a Vert.x 3 library [here](https://github.com/vietj/vertx-childprocess).

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.8.0</version>
+            <version>5.10.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/NuKernel32.java
@@ -85,6 +85,14 @@ public class NuKernel32
    public static native int WriteFile(HANDLE hFile, ByteBuffer lpBuffer, int nNumberOfBytesToWrite, IntByReference lpNumberOfBytesWritten,
                                       NuKernel32.OVERLAPPED lpOverlapped);
 
+	public static native HANDLE CreateJobObject(SECURITY_ATTRIBUTES attrs, String name);
+
+	public static native boolean SetInformationJobObject(HANDLE hJob, int JobObjectInfoClass, Pointer lpJobObjectInfo, int cbJobObjectInfoLength); // {return false;};
+
+	public static native boolean AssignProcessToJobObject(HANDLE hJob, HANDLE hProcess); // {return false;};
+
+	public static native boolean TerminateJobObject(HANDLE hJob, long uExitCode); // {return false;};
+
    /**
     * The OVERLAPPED structure contains information used in
     * asynchronous (or overlapped) input and output (I/O).


### PR DESCRIPTION
Shutdown hooks have bad behavior on Windows. Using Windows Job objects
ensure child processes die when the parent process (the NuProcess
caller) dies, regardless of the circumstances that caused the JVM
running NuProcess died.