### PR TITLE
Remove static EpollEvent queue. (fixes #126)

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -353,8 +353,9 @@ public abstract class BasePosixProcess implements NuProcess
          int read = LibC.read(fd, outBuffer, Math.min(availability, outBuffer.remaining()));
          if (read == -1) {
             outClosed = true;
-            throw new RuntimeException("Unexpected eof");
-            // EOF?
+
+            int errno = Native.getLastError();
+            throw new RuntimeException("Unexpected EOF reading stdout, errno: " + errno);
          }
 
          outBuffer.limit(outBuffer.position() + read);
@@ -390,9 +391,10 @@ public abstract class BasePosixProcess implements NuProcess
 
          int read = LibC.read(fd, errBuffer, Math.min(availability, errBuffer.remaining()));
          if (read == -1) {
-            // EOF?
             errClosed = true;
-            throw new RuntimeException("Unexpected eof");
+
+            int errno = Native.getLastError();
+            throw new RuntimeException("Unexpected EOF reading stderr, errno: " + errno);
          }
 
          errBuffer.limit(errBuffer.position() + read);

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -35,6 +35,8 @@ import static com.zaxxer.nuprocess.internal.Constants.JVM_MAJOR_VERSION;
  */
 public class LinuxProcess extends BasePosixProcess
 {
+   private final EpollEvent epollEvent;
+
    static {
       LibEpoll.sigignore(LibEpoll.SIGPIPE);
 
@@ -55,6 +57,8 @@ public class LinuxProcess extends BasePosixProcess
 
    LinuxProcess(NuProcessHandler processListener) {
       super(processListener);
+
+      epollEvent = new EpollEvent();
    }
 
    @Override
@@ -110,6 +114,17 @@ public class LinuxProcess extends BasePosixProcess
          LOGGER.log(Level.WARNING, "Failed to start process", e);
          onExit(Integer.MIN_VALUE);
       }
+   }
+
+   /**
+    * An {@link EpollEvent} struct, which may be used when registering for events for this process. Each process has
+    * its own struct to avoid concurrency issues in {@link ProcessEpoll#registerProcess} when multiple processes are
+    * registered at once (e.g. multiple threads are all starting new processes concurrently).
+    *
+    * @return this process's {@link EpollEvent} struct
+    */
+   EpollEvent getEpollEvent() {
+      return epollEvent;
    }
 
    private void prepareProcess(List<String> command, String[] environment, Path cwd) throws IOException


### PR DESCRIPTION
When creating many processes concurrently under load, it's possible to exhaust the 64 `EpollEvent`s in the queue and end up with threads blocked waiting for one to free up. If such a thread gets interrupted, it ends up leaking the process as a zombie.

I ran the jmh microbenchmark before and after this change to check the allocation rate and found no measurable difference. There was also no measurable difference in performance.

- Added an `EpollEvent` field to `LinuxProcess`
  - This way each process has its own event instance that can be used (and reused) whenever the processing thread needs to reconfigure the `epoll` registration
  - Since each write to `stdin` requires its own `EPOLLONESHOT` event, having a reusable `EpollEvent` avoids allocation churn
- Removed the `eventPool` in `ProcessEpoll` and updated it to use the process's `EpollEvent` when necessary
- Updated wording for a few `RuntimeException`s to make their messages a little more consistent, and added `errno` values to some that weren't including them to assist with debugging/analysis