### PR TITLE
FreeBSD Support - Fix syscall(SYS__pthread_chdir) failed to set current directory

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/LibC.java
@@ -81,7 +81,7 @@ public class LibC
    // We can't use JNA direct mapping for syscall(), since it takes varargs.
    public interface SyscallLibrary extends Library
    {
-      public static final int SYS___pthread_chdir = 348;
+      public static final int SYS___pthread_chdir = System.getProperty("os.name").toLowerCase().contains("freebsd") ? 12 : 348;
 
       int syscall(int syscall_number, Object... args);
    }

--- a/src/main/java/com/zaxxer/nuprocess/osx/LibKevent.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/LibKevent.java
@@ -59,6 +59,7 @@ public class LibKevent
       public int fflags;
       public NativeLong data;
       public Pointer udata;
+      public long[] ext = new long[4];
 
       public Kevent() {
           super();
@@ -72,7 +73,12 @@ public class LibKevent
       @Override
       protected List getFieldOrder()
       {
-         return Arrays.asList("ident", "filter", "flags", "fflags", "data", "udata");
+         String osname = System.getProperty("os.name").toLowerCase();
+         if(osname.contains("freebsd")){
+            return Arrays.asList("ident", "filter", "flags", "fflags", "data", "udata", "ext");
+         } else {
+            return Arrays.asList("ident", "filter", "flags", "fflags", "data", "udata");
+         }
       }
 
       Kevent EV_SET(long ident, int filter, int flags, int fflags, long data, Pointer udata)


### PR DESCRIPTION
Hello guys!

I am a developer and co-founder of Wiselabs Software in Brazil. We have some mission-critical systems that we chose to migrate to FreeBSD. In some of these systems we use NuProcess, and in the quality assurance process we found the following problem:

"syscall(SYS__pthread_chdir) failed to set current directory"

We also found a bug with the order in the process registration call (Kevent).

We chose to contribute to the project and resolve this bug. I hope it will be useful to you and other users.

Thank you so much for this wonderful library.