### PR TITLE
Add Automatic-Module-Name manifest entry to make NuProcess module-system-friendly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.4.0</version>
                 </plugin>
@@ -171,6 +176,19 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.zaxxer.nuprocess</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            
             <!-- Note: we might need this for removing side-effect on InterruptTest -->
             <!--plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            
             <!-- Note: we might need this for removing side-effect on InterruptTest -->
             <!--plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
A trivial PR that simply adds a manifest entry for `Automatic-Module-Name` which makes it possible to use this library from modular Java libraries and get a result that is safe to publish on Maven central.