### PR TITLE
Null injection hardening

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -107,6 +107,7 @@ public class NuProcessBuilder
       if (commands == null || commands.isEmpty()) {
          throw new IllegalArgumentException("List of commands may not be null or empty");
       }
+      ensureNoNullCharacters(commands);
 
       this.environment = new TreeMap<String, String>(environment);
       this.command = new ArrayList<String>(commands);
@@ -126,6 +127,7 @@ public class NuProcessBuilder
       if (commands == null || commands.isEmpty()) {
          throw new IllegalArgumentException("List of commands may not be null or empty");
       }
+      ensureNoNullCharacters(commands);
 
       this.environment = new TreeMap<String, String>(System.getenv());
       this.command = new ArrayList<String>(commands);
@@ -144,9 +146,11 @@ public class NuProcessBuilder
       if (commands == null || commands.length == 0) {
          throw new IllegalArgumentException("List of commands may not be null or empty");
       }
+      List<String> commandsList = Arrays.asList(commands);
+      ensureNoNullCharacters(commandsList);
 
       this.environment = new TreeMap<String, String>(System.getenv());
-      this.command = new ArrayList<String>(Arrays.asList(commands));
+      this.command = new ArrayList<String>(commandsList);
    }
 
    /**
@@ -277,6 +281,14 @@ public class NuProcessBuilder
    {
       if (processListener == null) {
          throw new IllegalArgumentException("NuProcessHandler not specified");
+      }
+   }
+
+   private void ensureNoNullCharacters(List<String> commands) {
+      for (String command : commands) {
+         if (command.indexOf('\u0000') >= 0) {
+            throw new IllegalArgumentException("Commands may not contain null characters");
+         }
       }
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessBuilder.java
@@ -107,7 +107,6 @@ public class NuProcessBuilder
       if (commands == null || commands.isEmpty()) {
          throw new IllegalArgumentException("List of commands may not be null or empty");
       }
-      ensureNoNullCharacters(commands);
 
       this.environment = new TreeMap<String, String>(environment);
       this.command = new ArrayList<String>(commands);
@@ -127,7 +126,6 @@ public class NuProcessBuilder
       if (commands == null || commands.isEmpty()) {
          throw new IllegalArgumentException("List of commands may not be null or empty");
       }
-      ensureNoNullCharacters(commands);
 
       this.environment = new TreeMap<String, String>(System.getenv());
       this.command = new ArrayList<String>(commands);
@@ -146,11 +144,9 @@ public class NuProcessBuilder
       if (commands == null || commands.length == 0) {
          throw new IllegalArgumentException("List of commands may not be null or empty");
       }
-      List<String> commandsList = Arrays.asList(commands);
-      ensureNoNullCharacters(commandsList);
 
       this.environment = new TreeMap<String, String>(System.getenv());
-      this.command = new ArrayList<String>(commandsList);
+      this.command = new ArrayList<String>(Arrays.asList(commands));
    }
 
    /**
@@ -257,6 +253,7 @@ public class NuProcessBuilder
     */
    public NuProcess start()
    {
+      ensureNoNullCharacters(command);
       ensureListener();
       String[] env = prepareEnvironment();
 
@@ -271,6 +268,7 @@ public class NuProcessBuilder
     */
    public void run()
    {
+      ensureNoNullCharacters(command);
       ensureListener();
       String[] env = prepareEnvironment();
 

--- a/src/test/java/com/zaxxer/nuprocess/RunTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/RunTest.java
@@ -316,6 +316,32 @@ public class RunTest
       System.err.println("Completed test softCloseStdinAfterWrite()");
    }
 
+   @Test(expected = IllegalArgumentException.class)
+   public void nullCommandViaCommandMutationWithRun() {
+      NuProcessBuilder pb = new NuProcessBuilder(new NullProcessHandler(), command);
+      pb.command().add("--foo\0--bar");
+      pb.run();
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void nullCommandViaCommandMutationWithStart() {
+      NuProcessBuilder pb = new NuProcessBuilder(new NullProcessHandler(), command);
+      pb.command().add("--foo\0--bar");
+      pb.start();
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void nullCommandViaConstructorWithRun() {
+      NuProcessBuilder pb = new NuProcessBuilder(new NullProcessHandler(), command, "--foo\0--bar");
+      pb.run();
+   }
+
+   @Test(expected = IllegalArgumentException.class)
+   public void nullCommandViaConstructorWithStart() {
+      NuProcessBuilder pb = new NuProcessBuilder(new NullProcessHandler(), command, "--foo\0--bar");
+      pb.start();
+   }
+
    private static byte[] getLotsOfBytes()
    {
       StringBuilder sb = new StringBuilder();
@@ -393,6 +419,9 @@ public class RunTest
       {
          return writes == WRITES && readAdler32.getValue() == writeAdler32.getValue();
       }
+   }
+
+   private static class NullProcessHandler extends NuAbstractProcessHandler {
    }
 
    private static class Utf8DecodingListener extends NuAbstractCharsetHandler


### PR DESCRIPTION
In `NuProcessBuilder` throw an `IllegalArgumentException` if commands that include a null character are passed. This hardens against command line injection type attacks in applications that use NuProcess.

The issue this aims to fix is described below. On Linux if you start a process with this list of arguments:
```
NuProcessBuilder pb = new NuProcessBuilder(Arrays.asList("/tmp/main", "--foo", "--bar=\0--bad", "--extra"));
```

One might expect you'd get arguments like this at the forked process (and indeed on MacOS you do, more on that later):
```
argv[0]: /tmp/main
argv[1]: --foo
argv[2]: --bar=
argv[3]: --extra
```

Or perhaps you'd expect an exception is thrown. But instead you get this:
```
argv[0]: /tmp/main
argv[1]: --foo
argv[2]: --bar=
argv[3]: --bad
```

The problem exists in NuProcess since 1.2.0 when it switched to using `Java_java_lang_UNIXProcess_forkAndExec()` and happens because the command array gets turned into a null separated string here:
https://github.com/brettwooldridge/NuProcess/blob/master/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java#L141-L147

That is necessary because `Java_java_lang_UNIXProcess_forkAndExec()` takes a string. And then in `Java_java_lang_UNIXProcess_forkAndExec()` it gets converted back to an array/vector, with the extra/injected null obviously being interpreted as a delimiter too:
https://github.com/adoptium/jdk8u/blob/master/jdk/src/solaris/native/java/lang/UNIXProcess_md.c#L608
https://github.com/adoptium/jdk8u/blob/master/jdk/src/solaris/native/java/lang/childproc.c#L166-L176

On MacOS this problem doesn't exist the forked process gets:
```
argv[0]: /tmp/main
argv[1]: --foo
argv[2]: --bar=
argv[3]: --extra
```

This is because MacOS uses `posix_spawnp()` which takes an array, so doesn't have this conversion to a null delimited string. I'm not sure how Windows behaves, I didn't test it.

The solution I used in our NuProcess fork was just to apply the same approach as Java's ProcessBuilder uses: https://github.com/adoptium/jdk8u/blob/master/jdk/src/share/classes/java/lang/ProcessBuilder.java#L1022-L1026

There is some scope to do some deduplication of code in the constructors of `NuProcessBuilder`. But I've just kept it simple for now. Happy to do that deduplication, or any other changes should that be desirable.