### PR TITLE
Native allocation free steady state on Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.11.0</version>
+            <version>5.14.0</version>
         </dependency>
 
         <dependency>
@@ -173,8 +173,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/zaxxer/nuprocess/NuProcessHandler.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcessHandler.java
@@ -99,10 +99,10 @@ public interface NuProcessHandler
     * <p>
     * Upon returning from this method, if any bytes are left in the buffer
     * (i.e., {@code buffer.hasRemaining()} returns {@code true}), then the
-    * buffer will be {@link ByteBuffer#compact() compacted} after returning. Any
-    * unused data will be kept at the start of the buffer and passed back to you
+    * buffer will be {@link ByteBuffer#clear()}ed at some point. Any
+    * unused data will <b>NOT</b> be kept at the start of the buffer and passed back to you
     * as part of the next invocation of this method (which might be when EOF is
-    * reached and {@code closed} is {@code true}).
+    * reached and {@code closed} is {@code true}). <b>This is a breaking change from the previous versions. </b>
     * <p>
     * Exceptions thrown out from your method will be ignored, but your method
     * should handle all exceptions itself.
@@ -123,10 +123,10 @@ public interface NuProcessHandler
     * <p>
     * Upon returning from this method, if any bytes are left in the buffer
     * (i.e., {@code buffer.hasRemaining()} returns {@code true}), then the
-    * buffer will be {@link ByteBuffer#compact() compacted} after returning. Any
-    * unused data will be kept at the start of the buffer and passed back to you
+    * buffer will be {@link ByteBuffer#clear()}ed at some point. Any
+    * unused data will <b>NOT</b> be kept at the start of the buffer and passed back to you
     * as part of the next invocation of this method (which might be when EOF is
-    * reached and {@code closed} is {@code true}).
+    * reached and {@code closed} is {@code true}). <b>This is a breaking change from the previous versions. </b>
     * <p>
     * Users wishing to merge stderr into stdout should simply delegate this
     * callback to {@link #onStdout(ByteBuffer, boolean)} when invoked, like so:

--- a/src/main/java/com/zaxxer/nuprocess/internal/JnaHelper.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/JnaHelper.java
@@ -1,0 +1,24 @@
+package com.zaxxer.nuprocess.internal;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+
+public class JnaHelper {
+
+    public static void free(IntByReference pointer) {
+        free((Memory) pointer.getPointer());
+    }
+
+    public static void free(Pointer pointer) {
+        if (pointer instanceof Memory) {
+            ((Memory) pointer).close();
+        } else {
+            throw new IllegalArgumentException("Expecting Pointer to be an instance of Memory");
+        }
+    }
+    public static void free(Memory memory) {
+        memory.close();
+    }
+
+}

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -35,7 +35,6 @@ import static com.zaxxer.nuprocess.internal.Constants.JVM_MAJOR_VERSION;
  */
 public class LinuxProcess extends BasePosixProcess
 {
-   private final EpollEvent epollEvent;
 
    static {
       LibEpoll.sigignore(LibEpoll.SIGPIPE);
@@ -57,8 +56,6 @@ public class LinuxProcess extends BasePosixProcess
 
    LinuxProcess(NuProcessHandler processListener) {
       super(processListener);
-
-      epollEvent = new EpollEvent();
    }
 
    @Override
@@ -114,17 +111,6 @@ public class LinuxProcess extends BasePosixProcess
          LOGGER.log(Level.WARNING, "Failed to start process", e);
          onExit(Integer.MIN_VALUE);
       }
-   }
-
-   /**
-    * An {@link EpollEvent} struct, which may be used when registering for events for this process. Each process has
-    * its own struct to avoid concurrency issues in {@link ProcessEpoll#registerProcess} when multiple processes are
-    * registered at once (e.g. multiple threads are all starting new processes concurrently).
-    *
-    * @return this process's {@link EpollEvent} struct
-    */
-   EpollEvent getEpollEvent() {
-      return epollEvent;
    }
 
    private void prepareProcess(List<String> command, String[] environment, Path cwd) throws IOException


### PR DESCRIPTION
While ~200KB mallocs per NuProcess on Linux might not sound as much. But a long running server process can create GBs of malloc calls that are first unnecessary and second might not be freeed for a long time causing OOM issues with Linux.

In my view it is bad practice to wait for Reference Handler to free native memory. A JVM  might take hours before calling reference processor on heaps that don't have much GC activity.

JNA will only free native memory via the reference processor unless in JNA 5.12 they added API to explicitly free native memory via `Memory#close` call.

I've moved Out/Err buffer from being per NuProcess to be per PosixProcessor. This way there is only ~200 KB overhead per processor and not per process. Now this can be called a low-overhead library.

Stdin handling is left unchanged with the exception of allocation on-demand of the 65K buffer per NuProcess. It gets explicitly freed on exit.

I need to test this some more and will possibly update the code some more. Feel free to review, add suggestions.

Sorry about Windows. Don't have Windows so not sure about it. Maybe we can just add the clear on buffer since the following is now true:

The only downside is an API breaking change. For `handler#onStdout` and `handler#onStderr` the buffer is cleared before each call. Which isn't a big deal or a problem that can't be fixed by an update to application code.

I think this sure beats getting OOM issues in production from native memory not being released by a server that is spawning 100s of processes per second. You are in GB/s per minute range soon if you do a lot of spawing.