### PR TITLE
Don't depend on the GC to free native memory on Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.11.0</version>
+            <version>5.13.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BaseEventProcessor.java
@@ -48,6 +48,8 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
    private CyclicBarrier startBarrier;
    private AtomicBoolean isRunning;
 
+   protected final IntByReference exitCodePointer = new IntByReference();
+
    static {
       LINGER_TIME_MS = Math.max(1000, Integer.getInteger("com.zaxxer.nuprocess.lingerTimeMs", 2500));
 
@@ -128,6 +130,7 @@ public abstract class BaseEventProcessor<T extends BasePosixProcess> implements 
          process.onExit(Integer.MAX_VALUE - 1);
          LibC.waitpid(process.getPid(), exitCode, LibC.WNOHANG);
       }
+      Util.close(exitCode);
    }
 
    /**

--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -323,8 +323,9 @@ public abstract class BasePosixProcess implements NuProcess
       }
       finally {
          exitPending.countDown();
-         // Once the last reference to the buffer is gone, Java will finalize the buffer
-         // and release the native memory we allocated in initializeBuffers().
+         outBufferMemory.close();
+         errBufferMemory.close();
+         inBufferMemory.close();
          outBufferMemory = null;
          errBufferMemory = null;
          inBufferMemory = null;
@@ -332,7 +333,6 @@ public abstract class BasePosixProcess implements NuProcess
          errBuffer = null;
          inBuffer = null;
          processHandler = null;
-         Memory.purge();
       }
    }
 

--- a/src/main/java/com/zaxxer/nuprocess/internal/Util.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/Util.java
@@ -1,0 +1,22 @@
+package com.zaxxer.nuprocess.internal;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
+
+public class Util {
+
+    public static void close(PointerType pointerType) {
+        if (pointerType == null) {
+            return;
+        }
+        close(pointerType.getPointer());
+    }
+
+    public static void close(Pointer p) {
+        if (p instanceof Memory) {
+            ((Memory) p).close();
+        }
+    }
+
+}

--- a/src/main/java/com/zaxxer/nuprocess/linux/EpollEvent.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/EpollEvent.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.sun.jna.*;
+import com.zaxxer.nuprocess.internal.Util;
 
 class EpollEvent
 {
@@ -62,6 +63,11 @@ class EpollEvent
 
    int size() {
       return size;
+   }
+
+   public void close()
+   {
+      Util.close(getPointer());
    }
 
    public static class EpollEventPrototype extends Structure

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -35,7 +35,6 @@ import static com.zaxxer.nuprocess.internal.Constants.JVM_MAJOR_VERSION;
  */
 public class LinuxProcess extends BasePosixProcess
 {
-   private final EpollEvent epollEvent;
 
    static {
       LibEpoll.sigignore(LibEpoll.SIGPIPE);
@@ -58,7 +57,6 @@ public class LinuxProcess extends BasePosixProcess
    LinuxProcess(NuProcessHandler processListener) {
       super(processListener);
 
-      epollEvent = new EpollEvent();
    }
 
    @Override
@@ -115,17 +113,6 @@ public class LinuxProcess extends BasePosixProcess
          LOGGER.log(Level.WARNING, "Failed to start process", e);
          onExit(Integer.MIN_VALUE);
       }
-   }
-
-   /**
-    * An {@link EpollEvent} struct, which may be used when registering for events for this process. Each process has
-    * its own struct to avoid concurrency issues in {@link ProcessEpoll#registerProcess} when multiple processes are
-    * registered at once (e.g. multiple threads are all starting new processes concurrently).
-    *
-    * @return this process's {@link EpollEvent} struct
-    */
-   EpollEvent getEpollEvent() {
-      return epollEvent;
    }
 
    private void prepareProcess(List<String> command, String[] environment, Path cwd) throws IOException

--- a/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/ProcessKqueue.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.ptr.IntByReference;
 import com.zaxxer.nuprocess.internal.BaseEventProcessor;
 import com.zaxxer.nuprocess.internal.LibC;
 import com.zaxxer.nuprocess.osx.LibKevent.Kevent;
@@ -393,7 +392,7 @@ final class ProcessKqueue extends BaseEventProcessor<OsxProcess>
 
    private void cleanupProcess(OsxProcess osxProcess)
    {
-      LibC.waitpid(osxProcess.getPid(), new IntByReference(), LibC.WNOHANG);
+      LibC.waitpid(osxProcess.getPid(), exitCodePointer, LibC.WNOHANG);
 
       // If this is the last process in the map, this thread will cleanly shut down.
       pidToProcessMap.remove(osxProcess.getPid());

--- a/src/test/java/com/zaxxer/nuprocess/ThreadLoadTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/ThreadLoadTest.java
@@ -1,0 +1,80 @@
+package com.zaxxer.nuprocess;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Yet another threaded test.
+ */
+public class ThreadLoadTest {
+
+    @Test
+    public void testStartLoad() throws InterruptedException {
+        int durationInMs = 15_000;
+        long cutOfTime = System.currentTimeMillis() + durationInMs;
+        int nrOfThreads = (Runtime.getRuntime().availableProcessors() * 2);
+        CountDownLatch latch = new CountDownLatch(nrOfThreads);
+        AtomicLong runCountCode0 = new AtomicLong();
+        AtomicLong runCountCodeNon0 = new AtomicLong();
+        AtomicLong problems = new AtomicLong();
+        for (int i = 0; i < nrOfThreads; i++) {
+            startNewThread(latch, cutOfTime, runCountCode0, runCountCodeNon0, problems);
+        }
+
+        Assert.assertTrue(latch.await(durationInMs + 1_000, TimeUnit.MILLISECONDS));
+        System.out.println("runCount 0 = " + runCountCode0.get());
+        System.out.println("runCount non-0 = " + runCountCodeNon0.get());
+        System.out.println("problems  = " + problems.get());
+    }
+
+    private void startNewThread(final CountDownLatch latch, final long cutOfTime, final AtomicLong zeroExit, final AtomicLong nonZeroExit, AtomicLong problems) {
+        new Thread(new Runnable() {
+            public void run() {
+                while (System.currentTimeMillis() < cutOfTime) {
+                    final int randomInt = ThreadLocalRandom.current().nextInt(10_000);
+                    final String text = "foo" + randomInt;
+                    long startTime = System.nanoTime();
+
+                    final NuProcess start = new NuProcessBuilder(new NuAbstractProcessHandler() {
+                        public void onPreStart(final NuProcess nuProcess) {
+                            super.onPreStart(nuProcess);
+                        }
+
+                        @Override
+                        public void onStart(NuProcess nuProcess) {
+                        }
+
+                        @Override
+                        public void onStdout(ByteBuffer buffer, boolean closed) {
+
+                        }
+
+                        public void onExit(final int statusCode) {
+                            if (statusCode == 0) {
+                                zeroExit.incrementAndGet();
+                            } else {
+                                nonZeroExit.incrementAndGet();
+                            }
+                        }
+                    }, "echo", text).start();
+                    try {
+                        start.waitFor(10, TimeUnit.DAYS);
+
+//                        System.out.println("Took " + ((System.nanoTime() - startTime) / 1000000));
+//                        start.wantWrite();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                latch.countDown();
+            }
+        }).start();
+    }
+}


### PR DESCRIPTION
JNA is freeing 192 KiB of per NuProcess native buffers on GC Finalizer / Reference Queue processing. In cases with very low GC activity, this is essentially a memory leak, potentially causing native memory issues.

  * out/err/in buffers are freed onExit,
  * event needed for Epoll #registerProcess and #queueWrite is allocated and freed in the method,
  * tweak in reusing of IntByReference for duration of epoll/kqueue processor,
  * updated JNA library to 5.13.0, to get #close on Memory object (added in 5.12.0).