### PR TITLE
Support for configuring NuProcess buffer capacity via user property

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ This property controls how long the processing thread(s) remains after the last 
 order to avoid the overhead of starting up another processing thread, if processes are frequently run it may be desirable
 for the processing thread to remain (linger) for some amount of time (default 2500ms).
 
+##### ``com.zaxxer.nuprocess.bufferCapacity``
+Sets the size of native `ByteBuffer` used for `NuProcessHandler#onStdout`, `#onStderr` and `#onStdinReady` methods.
+The default value is 65536 Bytes (64 KiB). Minimum value is 1 KiB and maximum 1 MiB. 
+
 #### Related Projects
 Charles Duffy has developed a Clojure wrapper library [here](https://github.com/threatgrid/asynp).
 Julien Viet has developed a Vert.x 3 library [here](https://github.com/vietj/vertx-childprocess).

--- a/src/main/java/com/zaxxer/nuprocess/NuProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/NuProcess.java
@@ -16,6 +16,8 @@
 
 package com.zaxxer.nuprocess;
 
+import com.zaxxer.nuprocess.internal.Constants;
+
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
@@ -40,7 +42,9 @@ import java.util.concurrent.TimeUnit;
  */
 public interface NuProcess
 {
-   int BUFFER_CAPACITY = 65536;
+   String BUFFER_CAPACITY_PROPERTY = "com.zaxxer.nuprocess.bufferCapacity";
+
+   int BUFFER_CAPACITY = Constants.getBufferCapacity();
 
    /**
     * Waits for the process to exit in a blocking fashion. See

--- a/src/main/java/com/zaxxer/nuprocess/internal/Constants.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/Constants.java
@@ -1,10 +1,21 @@
 package com.zaxxer.nuprocess.internal;
 
+import com.zaxxer.nuprocess.NuProcess;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 public class Constants
 {
+   private static final Logger LOGGER = Logger.getLogger(Constants.class.getCanonicalName());
+
    public static final int NUMBER_OF_THREADS;
    public static final int JVM_MAJOR_VERSION;
    static final OperatingSystem OS;
+
+   static final int DEFAULT_BUFFER_CAPACITY = 64 * 1024;
+   static final int MIN_BUFFER_CAPACITY = 1024;
+   static final int MAX_BUFFER_CAPACITY = 1024 * 1024;
 
    enum OperatingSystem
    {
@@ -46,4 +57,29 @@ public class Constants
           NUMBER_OF_THREADS = Math.max(1, Integer.parseInt(threads));
       }
    }
+
+    public static int getBufferCapacity() {
+        final String bufferCapacityProperty = System.getProperty(NuProcess.BUFFER_CAPACITY_PROPERTY);
+        if (bufferCapacityProperty == null || bufferCapacityProperty.trim().isEmpty()) {
+            return DEFAULT_BUFFER_CAPACITY;
+        }
+        try {
+            final int value = Integer.parseInt(bufferCapacityProperty);
+            if (value < MIN_BUFFER_CAPACITY) {
+                LOGGER.log(Level.WARNING, "Requested bufferCapacity of " + value + " is less than min, defaulting to min value of " + MIN_BUFFER_CAPACITY);
+                return MIN_BUFFER_CAPACITY;
+            }
+            else if (value > MAX_BUFFER_CAPACITY) {
+                LOGGER.log(Level.WARNING, "Requested bufferCapacity of " + value + " is more than max, defaulting to max value of " + MAX_BUFFER_CAPACITY);
+                return MAX_BUFFER_CAPACITY;
+            }
+            else {
+                return value;
+            }
+        }
+        catch (NumberFormatException e) {
+            return DEFAULT_BUFFER_CAPACITY;
+        }
+    }
+
 }

--- a/src/test/java/com/zaxxer/nuprocess/internal/ConstantsTest.java
+++ b/src/test/java/com/zaxxer/nuprocess/internal/ConstantsTest.java
@@ -1,5 +1,6 @@
 package com.zaxxer.nuprocess.internal;
 
+import com.zaxxer.nuprocess.NuProcess;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -16,4 +17,36 @@ public class ConstantsTest {
     Assert.assertEquals(8, Constants.getJavaMajorVersion("1.8"));
     Assert.assertEquals(11, Constants.getJavaMajorVersion("11"));
   }
+
+  @Test
+  public void checkDefaultBufferCapacity() {
+    System.setProperty(NuProcess.BUFFER_CAPACITY_PROPERTY, "");
+    Assert.assertEquals(Constants.DEFAULT_BUFFER_CAPACITY, Constants.getBufferCapacity());
+  }
+
+  @Test
+  public void settingUnparsableBufferCapacityDefaultsToDefault() {
+    System.setProperty(NuProcess.BUFFER_CAPACITY_PROPERTY, "foo");
+    Assert.assertEquals(Constants.DEFAULT_BUFFER_CAPACITY, Constants.getBufferCapacity());
+  }
+
+  @Test
+  public void settingSmallerBufferCapacityDefaultsToMin() {
+    System.setProperty(NuProcess.BUFFER_CAPACITY_PROPERTY, String.valueOf(Constants.MIN_BUFFER_CAPACITY - 1));
+    Assert.assertEquals(Constants.MIN_BUFFER_CAPACITY, Constants.getBufferCapacity());
+  }
+
+  @Test
+  public void settingLargerBufferCapacityDefaultsToMax() {
+    System.setProperty(NuProcess.BUFFER_CAPACITY_PROPERTY, String.valueOf(Constants.MAX_BUFFER_CAPACITY + 1));
+    Assert.assertEquals(Constants.MAX_BUFFER_CAPACITY, Constants.getBufferCapacity());
+  }
+
+  @Test
+  public void settingBufferCapacityNormalCase() {
+    int value = Constants.MIN_BUFFER_CAPACITY + (Constants.MAX_BUFFER_CAPACITY - Constants.MIN_BUFFER_CAPACITY) / 2;
+    System.setProperty(NuProcess.BUFFER_CAPACITY_PROPERTY, String.valueOf(value));
+    Assert.assertEquals(value, Constants.getBufferCapacity());
+  }
+
 }


### PR DESCRIPTION
Configurable via property `com.zaxxer.nuprocess.bufferCapacity`.

I've set the limits between 1 KiB and 1 MiB. They are arbitrary choices. Should handle use cases of 4, 8, 16, 32, 64 KB/KiB.

edit: could also set limit to something like 128 KiB? Thoughts?