### PR TITLE
Made thread name less generic and more specific to NuProcess.

### DIFF
--- a/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/BasePosixProcess.java
@@ -557,7 +557,7 @@ public abstract class BasePosixProcess implements NuProcess
       if (myProcessor.checkAndSetRunning()) {
          CyclicBarrier spawnBarrier = myProcessor.getSpawnBarrier();
 
-         Thread t = new Thread(myProcessor, "ProcessQueue" + mySlot);
+         Thread t = new Thread(myProcessor, "NuProcessQueue-" + mySlot);
          t.setDaemon(true);
          t.start();
 

--- a/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/windows/WindowsProcess.java
@@ -636,7 +636,7 @@ public final class WindowsProcess implements NuProcess
       if (myProcessor.checkAndSetRunning()) {
          CyclicBarrier spawnBarrier = myProcessor.getSpawnBarrier();
 
-         Thread t = new Thread(myProcessor, "ProcessIoCompletion" + mySlot);
+         Thread t = new Thread(myProcessor, "NuProcessIoCompletion-" + mySlot);
          t.setDaemon(true);
          t.start();
 


### PR DESCRIPTION
Seeing just "ProcessQueueN" show up in Linux system reports. It might be a bit confusing with all other system and application threads. With a more specific name it is easy to recognize this as a thread of NuProcess from looking at Linux logs and reports.