### PR TITLE
Prevent onStart/onExit race for fast-exiting processes.

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>nuprocess</artifactId>
-            <version>2.0.8-SNAPSHOT</version>
+            <version>2.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/mvnvm.properties
+++ b/mvnvm.properties
@@ -1,1 +1,1 @@
-mvn_version=3.8.5
+mvn_version=3.9.6

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.zaxxer</groupId>
     <artifactId>nuprocess</artifactId>
-    <version>2.0.8-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>NuProcess</name>

--- a/src/main/java/com/zaxxer/nuprocess/internal/IEventProcessor.java
+++ b/src/main/java/com/zaxxer/nuprocess/internal/IEventProcessor.java
@@ -54,6 +54,18 @@ public interface IEventProcessor<T extends BasePosixProcess> extends Runnable
    void registerProcess(T process);
 
    /**
+    * Queues read handling for the process's STDOUT and STDERR streams.
+    * <p>
+    * Prior to 2.1, this was performed by {@link #registerProcess}, but it was moved to a separate method
+    * to help avoid a race condition when starting a new process where soft exit detection could result in
+    * a fast-running process exiting before start was called on its process handler.
+    *
+    * @param process the process from which STDOUT and STDERR should be read
+    * @since 2.1
+    */
+   void queueRead(T process);
+
+   /**
     * Express that the client desires to write data into the STDIN stream as
     * soon as possible.
     *

--- a/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/linux/LinuxProcess.java
@@ -75,9 +75,15 @@ public class LinuxProcess extends BasePosixProcess
 
          afterStart();
 
+         // Registration must happen prior to calling NuProcessHandler.onStart to allow handlers
+         // to call wantWrite (which calls myProcessor.queueWrite)
          registerProcess();
 
          callStart();
+
+         // Queueing read handling for stdout and stderr happens after start has been called
+         // to ensure fast-exiting processes don't call NuProcessHandler.onExit before onStart
+         myProcessor.queueRead(this);
       }
       catch (Exception e) {
          // TODO remove from event processor pid map?

--- a/src/main/java/com/zaxxer/nuprocess/osx/OsxProcess.java
+++ b/src/main/java/com/zaxxer/nuprocess/osx/OsxProcess.java
@@ -65,7 +65,11 @@ class OsxProcess extends BasePosixProcess
 
          afterStart();
 
+         // On macOS, registration can be immediately followed by queueing read handling for stdout
+         // and stderr without risking a racy exit because processes are launched suspended and are
+         // only resumed after NuProcessHandler.onStart is called
          registerProcess();
+         myProcessor.queueRead(this);
 
          callStart();
 


### PR DESCRIPTION
Immediately after a `LinuxProcess` is registered with `ProcessEpoll`, it's possible for soft exit detection to detect process termination. If a process exits quickly, this means it's possible for `NuProcessHandler.onExit` to be called before `onStart`. When that happens, `BasePosixProcess.callStart` throws a `NullPointerException` because exit cleanup clears the process handler.

The top of such a call stack looks something like this:
```
May 01, 2024 1:38:24 AM com.zaxxer.nuprocess.internal.BasePosixProcess callStart
WARNING: Exception thrown from handler
java.lang.NullPointerException
	at com.zaxxer.nuprocess.internal.BasePosixProcess.callStart(BasePosixProcess.java:587)
	at com.zaxxer.nuprocess.linux.LinuxProcess.start(LinuxProcess.java:80)
	at com.zaxxer.nuprocess.linux.LinProcessFactory.createProcess(LinProcessFactory.java:40)
	at com.zaxxer.nuprocess.NuProcessBuilder.start(NuProcessBuilder.java:260)
```

This change splits the existing `IEventProcessor.registerProcess` method into two: `registerProcess`, and `queueRead` (a parallel to `queueWrite`). `registerProcess` sets up mappings (`pidToProcessMap`, `fildesToProcessMap`), and then `queueRead` does the `epoll` (or `kevent`, on macOS) operations.

This split ensures the process is registered before `onStart` is called, which is necessary to allow process handlers to call `wantWrite` during `onStart`, while also ensuring `stdout`/`stderr` aren't consumed until after `onStart` is called (which, in turn, prevents early soft-exit detection).

- Added `IEventProcessor.queueRead(T)`
  - Implementing classes now map the PID in `registerProcess` (as appropriate for the host OS), and then set up `epoll`/`kevent` state in `queueRead`
  - For synchronous processes (`NuProcess.run`), `queueRead` is called by the `ProcessEpoll`/`ProcessKqueue` constructors. There is no risk of a race because the process classes don't call `IEventProcessor.run` (which actually consumes events) until after `onStart` has been called
- Updated version to `2.1.0-SNAPSHOT` because a new interface method has been added
- Unrelated: Updated Maven to 3.9.6 (if using `mvnvm`)