### PR TITLE
Target Java 8 bytecode.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This was overlooked as part of dropping Java 7 support in NuProcess 3.0.