### PR TITLE
Explicit JPMS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependencies>
         <dependency>
             <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
+            <artifactId>jna-jpms</artifactId>
             <version>5.11.0</version>
         </dependency>
 
@@ -167,6 +167,11 @@
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>1.6.12</version>
                 </plugin>
+                <plugin>
+                    <groupId>io.github.dmlloyd.module-info</groupId>
+                    <artifactId>module-info</artifactId>
+                    <version>2.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -185,7 +190,7 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Automatic-Module-Name>com.zaxxer.nuprocess</Automatic-Module-Name>
+                            <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -217,6 +222,22 @@
                         <_noee>true</_noee>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.github.dmlloyd.module-info</groupId>
+                <artifactId>module-info</artifactId>
+                <executions>
+                    <execution>
+                        <id>module-info</id>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF/9</outputDirectory>
+                        </configuration>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/module-info.yml
+++ b/src/main/java/module-info.yml
@@ -1,0 +1,10 @@
+name: com.zaxxer.nuprocess
+requires:
+  - module: com.sun.jna
+exports:
+  - package: com.zaxxer.nuprocess
+  - package: com.zaxxer.nuprocess.codec
+  - package: com.zaxxer.nuprocess.internal
+  - package: com.zaxxer.nuprocess.linux
+  - package: com.zaxxer.nuprocess.osx
+  - package: com.zaxxer.nuprocess.windows


### PR DESCRIPTION
Motivation:

The library supports JPMS providing an automatic module name.

While this library aims to target Java 7, it remains possible using multi-release jar to support explicit JPMS modules.

Changes:

Update the build to use the module-info Maven jar which creates a module-info.class descriptor.

Update jna dependency to use jna-jpms which also is a multi release jar with a module-info descriptor.